### PR TITLE
[DEV-209] fix: ACCESS-TOKEN 재발급 시 잘못된 도메인 값이 들어가는 오류 수정

### DIFF
--- a/src/main/java/com/onedreamus/project/global/config/jwt/JWTFilter.java
+++ b/src/main/java/com/onedreamus/project/global/config/jwt/JWTFilter.java
@@ -28,10 +28,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JWTFilter extends OncePerRequestFilter {
 
     @Value("${spring.cookie.domain.server}")
-    private String SERVER_DOMAIN;
+    private final String SERVER_DOMAIN;
 
     @Value("${spring.cookie.domain.local}")
-    private String LOCAL_DOMAIN;
+    private final String LOCAL_DOMAIN;
 
     private final JWTUtil jwtUtil;
     private final UserRepository userRepository;


### PR DESCRIPTION
## Description
- DEV-209
- JWT 만료 후 재발급 시 domain값이 다르게 설정되어 쿠키가 발급되는 문제 발생
- @RequiredArgsConstructor 어노테이션 사용 시 생성자 주입 방식이 되므로 @Value를 사용하더라도 final로 설정해야 값이 주이됩.