### PR TITLE
[DEV-240] fix: 스크랩 기록 조회 시 2개 이상 조회되어 발생하는 오류로 스크랩이 안되는 문제 해결

### DIFF
--- a/src/main/java/com/onedreamus/project/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedreamus/project/global/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
 
             // Scarp
     SCRAP_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 스크랩 입니다."),
-    ALREADY_SCRAPPED(HttpStatus.BAD_REQUEST, "이미 스크랩된 항목 입니다."),
+    ALREADY_SCRAPPED(HttpStatus.BAD_REQUEST, "이미 스크랩된 용어이거나, 학습중인 용어입니다."),
 
     // KeyNote
     KEYNOTE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 핵심 노트에 존재하는 용어 입니다."),

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/DictionaryScrapRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/DictionaryScrapRepository.java
@@ -49,4 +49,6 @@ public interface DictionaryScrapRepository extends JpaRepository<DictionaryScrap
     );
 
     List<DictionaryScrap> findByUserAndIsDeletedFalse(Users user);
+
+    Boolean existsByUserAndDictionary(Users user, Dictionary dictionary);
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/ScrapService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/ScrapService.java
@@ -144,10 +144,9 @@ public class ScrapService {
                 .orElseThrow(() -> new DictionaryException(ErrorCode.DICTIONARY_NOT_EXIST));
 
         // 기존에 스크랩된 용어인지 확인
-        Optional<DictionaryScrap> DictionaryScrapOptional =
-                dictionaryScrapRepository.findByUserAndDictionaryAndIsDeleted(user, dictionary, false);
+        boolean isScrapped = dictionaryScrapRepository.existsByUserAndDictionary(user, dictionary);
 
-        if (DictionaryScrapOptional.isEmpty()) { // 스크랩된 적 없는 경우
+        if (!isScrapped) { // 스크랩된 적 없는 경우
              dictionaryScrapRepository.save(DictionaryScrap.make(user, dictionary));
         } else { // 이미 스크랩된 경우
             throw new ScrapException(ErrorCode.ALREADY_SCRAPPED);


### PR DESCRIPTION
## Description
- 오류 : 스크랩이 안되는 오류

- 원인

    - 정책상 스크랩 후 노트로 넘어간 스크랩은 다시 스크랩할 수 없음

    - findBy 를 통해 스크랩 기록을 조회해서 두 개 이상 값이 조회될 수 있는데 하나의 값만 받을 수 있도록 처리'

- 해결

    - existsBy 를 사용하여 조건에 해당하는 데이터가 하나 라도 있으면 boolean 값을 반환

    - 필요이상의 데이터 조회를 막을 수 있고, 발생한 오류 해결 가능