### PR TITLE
fix: 스크랩 용어 조회 시 삭제된 상태의 용어 스크랩은 조회하여 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/repository/DictionaryScrapRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/DictionaryScrapRepository.java
@@ -50,5 +50,7 @@ public interface DictionaryScrapRepository extends JpaRepository<DictionaryScrap
 
     List<DictionaryScrap> findByUserAndIsDeletedFalse(Users user);
 
-    Boolean existsByUserAndDictionary(Users user, Dictionary dictionary);
+    Boolean existsByUserAndDictionaryAndIsDeleted(Users user, Dictionary dictionary, boolean isDeleted);
+
+    Optional<DictionaryScrap> findByIdAndUserAndIsDeleted(Long dictionaryScrapId, Users user, boolean b);
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/ScrapService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/ScrapService.java
@@ -120,10 +120,10 @@ public class ScrapService {
                 .orElseThrow(() -> new ContentException(ErrorCode.CONTENT_NOT_EXIST));
 
         // 기존에 스크랩된 용어인지 확인
-        Optional<DictionaryScrap> DictionaryScrapOptional =
+        Optional<DictionaryScrap> dictionaryScrapOptional =
                 dictionaryScrapRepository.findByUserAndDictionaryAndIsDeleted(user, dictionary, false);
 
-        if (DictionaryScrapOptional.isEmpty()) { // 스크랩된 적 없는 경우
+        if (dictionaryScrapOptional.isEmpty()) { // 스크랩된 적 없는 경우
 
             DictionaryScrap newDictionaryScrap =
                     dictionaryScrapRepository.save(DictionaryScrap.make(user, dictionary));
@@ -144,7 +144,7 @@ public class ScrapService {
                 .orElseThrow(() -> new DictionaryException(ErrorCode.DICTIONARY_NOT_EXIST));
 
         // 기존에 스크랩된 용어인지 확인
-        boolean isScrapped = dictionaryScrapRepository.existsByUserAndDictionary(user, dictionary);
+        boolean isScrapped = dictionaryScrapRepository.existsByUserAndDictionaryAndIsDeleted(user, dictionary, false);
 
         if (!isScrapped) { // 스크랩된 적 없는 경우
              dictionaryScrapRepository.save(DictionaryScrap.make(user, dictionary));
@@ -188,7 +188,7 @@ public class ScrapService {
      * - scrap ID로 삭제
      */
     public void deleteDictionaryScrapped(Long dictionaryScrapId, Users user) {
-        DictionaryScrap dictionaryScrap = dictionaryScrapRepository.findByIdAndUser(dictionaryScrapId, user)
+        DictionaryScrap dictionaryScrap = dictionaryScrapRepository.findByIdAndUserAndIsDeleted(dictionaryScrapId, user, false)
                 .orElseThrow(() -> new ScrapException(ErrorCode.SCRAP_NOT_EXIST));
 
         dictionaryScrap.setIsDeleted(true);


### PR DESCRIPTION
## Description
- 용어 스크랩 삭제, 조회 시` NonUniqueResultException `발생
    - `findByUserAndDictionary(user, dictionary)` 사용 시 삭제 상태인 용어 스크랩도 조회하여 `NonUniqueResultException` 에러 발생
    - `findByUserAndDictionaryAndIsDeleted(user, dictionary, false)` 로 소중하여 삭제 상태인 용어 스크랩은 조회하지 않도록 수정 