### PR TITLE
refactor: prometheus 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 }
 

--- a/src/main/java/com/onedreamus/project/global/config/jwt/JWTFilter.java
+++ b/src/main/java/com/onedreamus/project/global/config/jwt/JWTFilter.java
@@ -206,7 +206,8 @@ public class JWTFilter extends OncePerRequestFilter {
             "/swagger-ui/**",
             "/v1/contents/**",
             "/v1/contents",
-                "/v1/users/join/social", "/v1/users/unlink/social"
+                "/v1/users/join/social", "/v1/users/unlink/social",
+                "/actuator/**"
         );
 
         return publicPaths.stream().anyMatch(publicPath ->

--- a/src/main/java/com/onedreamus/project/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/onedreamus/project/global/config/security/SecurityConfig.java
@@ -96,7 +96,7 @@ public class SecurityConfig {
 					"login/**", "/users/join", "/oauth2/**", "/swagger-ui.html",
 					"/v3/api-docs/**", "/swagger-ui/**", "/v1/contents/**", "/v1/contents", "/v1/auth/check",
 						"/v1/users/join/social",
-						"/v1/users/unlink/social", "/v1/contents/news/**"
+						"/v1/users/unlink/social", "/v1/contents/news/**", "/actuator/**"
 				).permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.requestMatchers("/v1/users/info", "/v1/scraps/**", "/v1/users/withdraw",


### PR DESCRIPTION
## Description
> 서버 응답속도가 계속 느려지는데 원인을 찾지 못하고 있어서 모니터링 환경 도입 결정
- promtheus, grafana를 활용한 모니터링 환경 세팅
- 서버에 구축 X -> 서버는 관련 path만 열어놓고 로컬에 환경 구축
    - prometheus 가 metrics를 수집한 후 저장하면서 ec2 서버 리소스를 많이 사용하게 될거라고 예상
    - 현재 좋지 않은 서버(ec2-t2.micro)를 사용하고 있기 때문에 로컬에 prometheus, grafana를 세팅하기로 결정
    - prometheus 기본 설정 만으로도 수백 MB 사용