### PR TITLE
Feat: 누적 학습 일수 카운팅 및 조회 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@ gradle-app.setting
 
 application-dev.yml
 application-deploy.yml
+prometheus.yml
 
 Todo.md
 

--- a/src/main/java/com/onedreamus/project/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/onedreamus/project/global/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.onedreamus.project.global.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * <p>[권한 부족 에러 처리]</p>
+ * 권한 부족으로 에러가 발생할 경우 사용됨.
+ */
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorizedddd");
+
+    }
+}

--- a/src/main/java/com/onedreamus/project/global/util/NumberUtils.java
+++ b/src/main/java/com/onedreamus/project/global/util/NumberUtils.java
@@ -1,9 +1,6 @@
 package com.onedreamus.project.global.util;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class NumberUtils {
 
@@ -11,7 +8,7 @@ public class NumberUtils {
      * 0 ~ max 사이의 수에서
      * n개의 랜덤 수를 뽑기
      */
-    public static List<Long> pickRandomNumber(long max, int n) {
+    public static List<Long> pickRandomNumList(long max, int n) {
 
         if (n > max) {
             throw new RuntimeException("숫자 배열의 크기보다 뽑으려는 숫자 개수가 더 큽니다.");
@@ -19,24 +16,6 @@ public class NumberUtils {
 
         List<Long> numbers = new ArrayList<>();
         for (long i = 0; i < max; i++) {
-            numbers.add(i);
-        }
-
-        Collections.shuffle(numbers);
-        return numbers.subList(0, n);
-    }
-
-    public static List<Long> pickRandomNumber(long max, int n, Set<Long> excludedNumbers) {
-
-        if (n > max) {
-            throw new RuntimeException("숫자 배열의 크기보다 뽑으려는 숫자 개수가 더 큽니다.");
-        }
-
-        List<Long> numbers = new ArrayList<>();
-        for (long i = 0; i < max; i++) {
-            if (excludedNumbers.contains(i)) {
-                continue;
-            }
             numbers.add(i);
         }
 
@@ -52,5 +31,27 @@ public class NumberUtils {
 
         Collections.shuffle(numbers);
         return numbers;
+    }
+
+    public static List<Integer> pickRandomNumList(int minNum, int maxNum, int cnt) {
+        Set<Integer> randomNumSet = new HashSet<>();
+        Random random = new Random();
+        while (randomNumSet.size() < cnt) {
+            randomNumSet.add(pickRandomNum(minNum, maxNum));
+        }
+
+        return new ArrayList<>(randomNumSet);
+    }
+
+    /**
+     * <p>[랜덤 숫자 획득]</p>
+     * minNum으로 시작해서 maxNum으로 끝나는 연속된 수 사이에서 랜덤한 수를 뽑음
+     * @param minNum
+     * @param maxNum
+     * @return
+     */
+    public static int pickRandomNum(int minNum, int maxNum) {
+        Random random = new Random();
+        return random.nextInt(maxNum) + minNum;
     }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/ContentController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/ContentController.java
@@ -64,30 +64,38 @@ public class ContentController {
 		return ResponseEntity.ok(contentService.getContentDetail(contentId));
 	}
 
-	@GetMapping("/news")
-	@Operation(summary = "뉴스 콘텐츠 목록 조회", description = "여러 개의 뉴스 목록을 가져옵니다. 최신 뉴스부터 조회 할 수 있습니다. 'cursor'를 사용해 마지막으로 본 뉴스 이후부터 조회할 수 있습니다.")
-	public ResponseEntity<CursorResult<NewsListResponse>> getNewsList(
-		@Parameter(description = "마지막으로 조회된 콘텐츠의 ID (첫 페이지 조회 시 null)",
-			example = "123")
-		@RequestParam(required = false) Integer cursor,
-		@Parameter(description = "한 번에 가져올 콘텐츠의 개수",
-			example = "10",
-			schema = @Schema(minimum = "1", maximum = "100"))
-		@RequestParam(defaultValue = "10") int size
-	) {
-		return ResponseEntity.ok(newsService.getNewList(cursor, size));
-	}
+    // -----------[ News Contents ]---------
+
+    @GetMapping("/news")
+    @Operation(summary = "뉴스 콘텐츠 목록 조회", description = "여러 개의 뉴스 목록을 가져옵니다. 최신 뉴스부터 조회 할 수 있습니다. 'cursor'를 사용해 마지막으로 본 뉴스 이후부터 조회할 수 있습니다.")
+    public ResponseEntity<CursorResult<NewsListResponse>> getNewsList(
+            @Parameter(description = "마지막으로 조회된 콘텐츠의 ID (첫 페이지 조회 시 null)",
+                    example = "123")
+            @RequestParam(required = false) Integer cursor,
+            @Parameter(description = "한 번에 가져올 콘텐츠의 개수",
+                    example = "10",
+                    schema = @Schema(minimum = "1", maximum = "100"))
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(newsService.getNewList(cursor, size));
+    }
 
 	@GetMapping("/news/{newsId}")
 	@Operation(summary = "뉴스 상세페이지 조회", description = "뉴스 상세페이지로 이동하여 학습을 합니다.")
-	public ResponseEntity<NewsDetailResponse> getNewsDetail(@PathVariable Integer newsId) {
-		return ResponseEntity.ok(newsService.getNewsDetail(newsId));
+	public ResponseEntity<NewsDetailResponse> getNewsDetail(@PathVariable Integer newsId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		NewsDetailResponse newsDetailResponse;
+		if (userDetails == null) {
+			newsDetailResponse = newsService.getNewsDetail(newsId);
+		}else {
+			newsDetailResponse = newsService.getNewsDetail(newsId, userDetails.getUser());
+		}
+		return ResponseEntity.ok(newsDetailResponse);
 	}
 
-	@GetMapping("/news/latest")
-	@Operation(summary = "가장 최근 콘텐츠 조회", description = "가장 최근에 업로드된 콘텐츠 1개를 가져옵니다.")
-	public ResponseEntity<NewsListResponse> getLatestNews() {
-		return ResponseEntity.ok(newsService.getLatestNews());
-	}
+    @GetMapping("/news/latest")
+    @Operation(summary = "가장 최근 콘텐츠 조회", description = "가장 최근에 업로드된 콘텐츠 1개를 가져옵니다.")
+    public ResponseEntity<NewsListResponse> getLatestNews() {
+        return ResponseEntity.ok(newsService.getLatestNews());
+    }
 
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/UserController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/UserController.java
@@ -118,7 +118,7 @@ public class UserController {
 
         List<String> cookies = userService.unlinkSocial(request);
 
-        for(String cookie : cookies){
+        for (String cookie : cookies) {
             response.addHeader(HttpHeaders.SET_COOKIE, cookie);
         }
 
@@ -147,4 +147,11 @@ public class UserController {
         );
     }
 
+    @GetMapping("/study-days/count")
+    @Operation(summary = "누적 학습 일수 조회", description = "누적된 학습 일수를 조회합니다.")
+    public ResponseEntity<StudyDaysCountDto> getStudyDaysCount(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        StudyDaysCountDto studyDaysCountDto = userService.getStudyDaysCount(userDetails.getUser());
+        return ResponseEntity.ok(studyDaysCountDto);
+    }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/StudyDaysCountDto.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/StudyDaysCountDto.java
@@ -1,0 +1,22 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class StudyDaysCountDto {
+
+    private int studyDaysCnt;
+
+    public static StudyDaysCountDto from(int totalStudyDays) {
+
+        return StudyDaysCountDto.builder()
+                .studyDaysCnt(totalStudyDays)
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/UsersStudyDays.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/UsersStudyDays.java
@@ -1,0 +1,27 @@
+package com.onedreamus.project.thisismoney.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class UsersStudyDays {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn
+    @ManyToOne
+    private Users user;
+
+    private LocalDate studyDate;
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/UsersStudyDaysRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/UsersStudyDaysRepository.java
@@ -1,0 +1,15 @@
+package com.onedreamus.project.thisismoney.repository;
+
+import com.onedreamus.project.thisismoney.model.entity.Users;
+import com.onedreamus.project.thisismoney.model.entity.UsersStudyDays;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+public interface UsersStudyDaysRepository extends JpaRepository<UsersStudyDays, Long> {
+    int countByUser(Users user);
+
+    boolean existsByUserAndStudyDate(Users user, LocalDate now);
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/service/QuizService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/QuizService.java
@@ -45,8 +45,10 @@ public class QuizService {
         }
 
         // 랜덤으로 3개의 단어 뽑음
-        Collections.shuffle(dictionaries1);
-        quizDictionaries.addAll(dictionaries1.subList(0, 3));
+        List<Integer> randomNumList = NumberUtils.pickRandomNumList(0, dictionaries1.size() - 1, 3);
+        for (int idx : randomNumList) {
+            quizDictionaries.add(dictionaries1.get(idx));
+        }
 
         // 2. 2문제 : 전체 단어 중 랜덤 선택
         long maxId = dictionaryService.getMaxId();
@@ -105,7 +107,7 @@ public class QuizService {
      * notBeDuplicatedNum에 중복되지 않는 dictionary를 n개 구하는 함수.
      */
     private List<Dictionary> getRandomDictionary(long maxId, int n, Set<Long> notBeDuplicatedNum) {
-        List<Long> randomNumList = NumberUtils.pickRandomNumber(maxId, n);
+        List<Long> randomNumList = NumberUtils.pickRandomNumList(maxId, n);
         Set<Long> randomNumSet = new HashSet<>();
         for (Long randNum : randomNumList) {
             if (!notBeDuplicatedNum.contains(randNum)) {
@@ -120,7 +122,7 @@ public class QuizService {
             // 1. 부족 수 만큼 랜덤 수 뽑기
             // - 근데 이전에 뽑은 랜덤 수와 중복되면 안댐.
             int insufficientNum = n - result.size();
-            List<Long> newRandomNum = NumberUtils.pickRandomNumber(maxId, insufficientNum);
+            List<Long> newRandomNum = NumberUtils.pickRandomNumList(maxId, insufficientNum);
             List<Long> notDuplicate = new ArrayList<>();
             for (Long randomNum : newRandomNum) {
                 if (randomNumSet.contains(randomNum)) {

--- a/src/main/java/com/onedreamus/project/thisismoney/service/UserService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/UserService.java
@@ -6,10 +6,12 @@ import com.onedreamus.project.global.exception.LoginException;
 import com.onedreamus.project.thisismoney.exception.UserException;
 import com.onedreamus.project.thisismoney.model.dto.*;
 import com.onedreamus.project.thisismoney.model.entity.Users;
+import com.onedreamus.project.thisismoney.model.entity.UsersStudyDays;
 import com.onedreamus.project.thisismoney.repository.UserRepository;
 import com.onedreamus.project.global.config.jwt.TokenType;
 import com.onedreamus.project.global.exception.ErrorCode;
 import com.onedreamus.project.global.util.CookieUtils;
+import com.onedreamus.project.thisismoney.repository.UsersStudyDaysRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -36,7 +38,7 @@ public class UserService {
     private final ContentHistoryService contentHistoryService;
     private final UserChecker userChecker;
     private final JWTUtil jwtUtil;
-    private final NoteService noteService;
+    private final UsersStudyDaysRepository usersStudyDaysRepository;
 
     public void saveUser(Users user) {
         userRepository.save(user);
@@ -177,4 +179,17 @@ public class UserService {
     public FirstQuizAttemptResponse checkFirstAttempt(Users user) {
         return new FirstQuizAttemptResponse(!user.isQuizAttempt());
     }
+
+    /**\
+     * <p>총 학습일수 계산</p>
+     * @param user
+     * @return
+     */
+    public StudyDaysCountDto getStudyDaysCount(Users user) {
+
+        int totalStudyDays = usersStudyDaysRepository.countByUser(user);
+
+        return StudyDaysCountDto.from(totalStudyDays);
+    }
+
 }


### PR DESCRIPTION
## Description
- 누적 학습 일수 카운팅 기능 추가
    - 학습 날짜를 통해 해당 날짜에 학습 카운팅이 돼있다면 그날 학습에 대한 카운팅은 더이상 진행되지 않도록 함.
    - 비로그인 유저의 경우 카운팅이 없어야 하기 때문에 로직을 분리
    - 로그인 유무에 따라 API를 분리하면 URI가 Restful하게 작성되기 어렵고, 프론트에서 로직 수정이 필요하다는 문제가 발생하여 기존 URI를 유지하도록 수정
    - 기존에는 JWTFilter에서 권한 필요 유무에 따라 처리를 했지만 현재는 모든 요청에 대해 처리하도록 하여 로그인 유무에 따라 SecurityContextHolder 에 값이 있고 없고가 나뉘어지도록 만 했다. 
    - 권한 관련 처리는 다음 필터에서 처리하도록 역할을 분명하게 분리시킴.