### PR TITLE
[DEV-242] fix: 다른 소셜로그인과 충돌하지 않도록 이메일, provider로 기존 유저인지 확인

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/repository/UserRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<Users, Integer> {
     Boolean existsByEmail(String email);
 
     Optional<Users> findByEmail(String email);
+
+    Optional<Users> findByEmailAndProvider(String email, String provider);
+
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/CustomOAuth2UserService.java
@@ -45,7 +45,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String nickname = oAuth2Response.getProvider() + "_" + oAuth2Response.getProviderId();
 
-        Optional<Users> userOptional = userRepository.findByEmail(oAuth2Response.getEmail());
+        Optional<Users> userOptional = userRepository.findByEmailAndProvider(oAuth2Response.getEmail(), oAuth2Response.getProvider());
 
         UserDto userDto;
         Users user;


### PR DESCRIPTION
## Description
- issue : [DEV-242]
    - 기존 유저인지 확인할 때 이메일, provider를 통해 유저를 조회하도록 수정
    - 이전에 사용한 소결로그인과 다른 소셜로그인으로 회원가입할 때 이메일만으로 조회해서 덮어 써지는 문제 해결

[DEV-242]: https://6bit.atlassian.net/browse/DEV-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ