### PR TITLE
fix: refresh-token 만료시간 일시 수정(프론트 에러 처리 확인 용)

### DIFF
--- a/src/main/java/com/onedreamus/project/global/config/jwt/TokenType.java
+++ b/src/main/java/com/onedreamus/project/global/config/jwt/TokenType.java
@@ -10,17 +10,18 @@ import java.util.List;
 @AllArgsConstructor
 public enum TokenType {
 
-    REFRESH_TOKEN("REFRESH-TOKEN", 60 * 24 * 5 * 60 * 1000L), // 5일
-    ACCESS_TOKEN("ACCESS-TOKEN" ,10 * 60 * 1000L), // 10분
+    //    REFRESH_TOKEN("REFRESH-TOKEN", 60 * 24 * 5 * 60 * 1000L), // 5일
+    REFRESH_TOKEN("REFRESH-TOKEN", 20 * 60 * 1000L),
+    ACCESS_TOKEN("ACCESS-TOKEN", 10 * 60 * 1000L), // 10분
     VERIFY_TOKEN("VERIFY-TOKEN", 3 * 60 * 1000L);
 
     private final String name;
     private final Long expiredTime;
 
-    public static List<String> getAllTokenName(){
+    public static List<String> getAllTokenName() {
         return Arrays.stream(TokenType.values())
-                .map(TokenType::getName)
-                .toList();
+            .map(TokenType::getName)
+            .toList();
     }
 
 }


### PR DESCRIPTION
## Description
- 프론트엔드에서 refresh-token 만료시 발생하는 에러처리 테스트 용으로 만료 시간 단축
- 만료시간 변화 : 5일 -> 20분
- **프론트엔드 에러 처리 테스트 완료 후 바로 원복 예정**