### PR TITLE
fix: 토큰 만료 시간 일시 수정

### DIFF
--- a/src/main/java/com/onedreamus/project/global/config/jwt/TokenType.java
+++ b/src/main/java/com/onedreamus/project/global/config/jwt/TokenType.java
@@ -11,8 +11,8 @@ import java.util.List;
 public enum TokenType {
 
     //    REFRESH_TOKEN("REFRESH-TOKEN", 60 * 24 * 5 * 60 * 1000L), // 5일
-    REFRESH_TOKEN("REFRESH-TOKEN", 20 * 60 * 1000L),
-    ACCESS_TOKEN("ACCESS-TOKEN", 10 * 60 * 1000L), // 10분
+    REFRESH_TOKEN("REFRESH-TOKEN", 4 * 60 * 1000L),
+    ACCESS_TOKEN("ACCESS-TOKEN", 3 * 60 * 1000L), // 10분
     VERIFY_TOKEN("VERIFY-TOKEN", 3 * 60 * 1000L);
 
     private final String name;


### PR DESCRIPTION
## Description
- 프론트엔드에서 refresh-token 만료시 발생하는 에러처리 테스트 용으로 만료 시간 단축
- 만료시간 변화 : 5일 -> 20분
- **프론트엔드 에러 처리 테스트 완료 후 바로 원복 예정**