### PR TITLE
[DEV-254] fix: 썸네일 URL 컬럼 크기 증가

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/News.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/News.java
@@ -1,5 +1,6 @@
 package com.onedreamus.project.thisismoney.model.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,6 +25,7 @@ public class News {
     private Integer id;
 
     private String title;
+    @Column(length = 400)
     private String thumbnailUrl;
     private LocalDateTime createdAt;
     private Boolean isDeleted;


### PR DESCRIPTION
## Description
- issue : [DEV-254]
    - 백오피스에서 썸네일 URL의 길이가 255를 초과하여 삽입이 안되는 에러가 발생
    - **썸네일 URL 컬럼의 최대 길이를 400으로 증가**

[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ