### PR TITLE
[DEV-254] 백오피스 업로드 Validator 추가 및 뉴스 리스트 조회 API 추가

### DIFF
--- a/src/main/java/com/onedreamus/project/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/onedreamus/project/global/config/security/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
         "/v1/contents", "/v1/auth/check",
         "/v1/users/join/social",
         "/v1/users/unlink/social", "/v1/contents/news/**", "/actuator/**",
-        "/v1/dictionary/**"
+        "/v1/dictionary/**",
+        "/v1/back-office/**"
     };
 
     private final String[] USER_PATHS = {

--- a/src/main/java/com/onedreamus/project/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onedreamus/project/global/exception/GlobalExceptionHandler.java
@@ -2,9 +2,14 @@ package com.onedreamus.project.global.exception;
 
 import com.onedreamus.project.global.exception.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.*;
 
 @RestControllerAdvice
 @Slf4j
@@ -16,5 +21,16 @@ public class GlobalExceptionHandler {
 
         ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Set<String>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        Set<String> errors = new HashSet<>();
+
+
+        e.getBindingResult().getFieldErrors()
+                .forEach(fieldError -> errors.add(fieldError.getDefaultMessage()));
+
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/onedreamus/project/global/validator/DictionarySentenceValidator.java
+++ b/src/main/java/com/onedreamus/project/global/validator/DictionarySentenceValidator.java
@@ -1,0 +1,43 @@
+package com.onedreamus.project.global.validator;
+
+import com.onedreamus.project.thisismoney.model.dto.DictionarySentenceRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class DictionarySentenceValidator implements ConstraintValidator<ValidDictionarySentence, DictionarySentenceRequest> {
+    @Override
+    public boolean isValid(DictionarySentenceRequest request, ConstraintValidatorContext context) {
+        // 만약 객체 자체가 null이면 다른 제약으로 처리하거나 true로 반환
+        if (request == null) {
+            return true;
+        }
+        // dictionaryId가 존재하면 나머지 필드는 검사하지 않음
+        if (request.getDictionaryId() != null) {
+            return true;
+        }
+
+        // dictionaryId가 null인 경우, 세 필드가 반드시 존재해야 함
+        boolean valid = true;
+        context.disableDefaultConstraintViolation(); // 기본 메시지 비활성화
+
+        if (request.getDictionaryTerm() == null || request.getDictionaryTerm().trim().isEmpty()) {
+            context.buildConstraintViolationWithTemplate("dictionaryTerm은 필수 값입니다.")
+                    .addPropertyNode("dictionaryTerm")
+                    .addConstraintViolation();
+            valid = false;
+        }
+        if (request.getDictionaryDefinition() == null || request.getDictionaryDefinition().trim().isEmpty()) {
+            context.buildConstraintViolationWithTemplate("dictionaryDefinition은 필수 값입니다.")
+                    .addPropertyNode("dictionaryDefinition")
+                    .addConstraintViolation();
+            valid = false;
+        }
+        if (request.getDictionaryDescription() == null || request.getDictionaryDescription().trim().isEmpty()) {
+            context.buildConstraintViolationWithTemplate("dictionaryDescription은 필수 값입니다.")
+                    .addPropertyNode("dictionaryDescription")
+                    .addConstraintViolation();
+            valid = false;
+        }
+        return valid;
+    }
+}

--- a/src/main/java/com/onedreamus/project/global/validator/ValidDictionarySentence.java
+++ b/src/main/java/com/onedreamus/project/global/validator/ValidDictionarySentence.java
@@ -1,0 +1,16 @@
+package com.onedreamus.project.global.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = DictionarySentenceValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDictionarySentence {
+    String message() default "dictionaryId가 없으면 dictionaryTerm, dictionaryDefinition, dictionaryDescription은 필수입니다.";
+    Class<?>[] groups() default{};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -4,6 +4,7 @@ import com.onedreamus.project.thisismoney.model.dto.*;
 import com.onedreamus.project.thisismoney.service.NewsService;
 import com.onedreamus.project.thisismoney.service.ScheduledNewsService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @RestController
-@RequestMapping("/back-office")
+@RequestMapping("/v1/back-office")
 @RequiredArgsConstructor
 public class BackOfficeController {
 
@@ -23,7 +24,7 @@ public class BackOfficeController {
 
     @PostMapping("/contents/news")
     @Operation(summary = "뉴스 콘텐츠 즉시 업로드", description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다.")
-    public ResponseEntity<String> uploadNews(@RequestBody NewsRequest newsRequest) {
+    public ResponseEntity<String> uploadNews(@Valid @RequestBody NewsRequest newsRequest) {
         newsService.uploadNews(newsRequest);
         return ResponseEntity.ok("콘텐츠 등록 완료");
     }
@@ -31,7 +32,7 @@ public class BackOfficeController {
     @PostMapping("/contents/news/scheduled/{scheduledAt}")
     @Operation(summary = "뉴스 콘텐츠 업로드 예약", description = "뉴스 콘텐츠 업로드 날짜를 설정하고 예약 합니다.")
     public ResponseEntity<String> scheduleContentUpload(
-            @RequestBody NewsRequest newsRequest,
+            @Valid @RequestBody NewsRequest newsRequest,
             @PathVariable("scheduledAt") LocalDate scheduledAt) {
         scheduledNewsService.scheduleUploadNews(newsRequest, scheduledAt);
         return ResponseEntity.ok("콘텐츠 등록 완료");
@@ -59,6 +60,5 @@ public class BackOfficeController {
     public ResponseEntity<NewsDetailResponse> getNewsDetail(@PathVariable("newsId") Integer newsId) {
         NewsDetailResponse newsDetailResponse = newsService.getNewsDetail(newsId);
         return ResponseEntity.ok(newsDetailResponse);
-
     }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -1,0 +1,64 @@
+package com.onedreamus.project.thisismoney.controller;
+
+import com.onedreamus.project.thisismoney.model.dto.*;
+import com.onedreamus.project.thisismoney.service.NewsService;
+import com.onedreamus.project.thisismoney.service.ScheduledNewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/back-office")
+@RequiredArgsConstructor
+public class BackOfficeController {
+
+    private final ScheduledNewsService scheduledNewsService;
+    private final NewsService newsService;
+
+    @PostMapping("/contents/news")
+    @Operation(summary = "뉴스 콘텐츠 즉시 업로드", description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다.")
+    public ResponseEntity<String> uploadNews(@RequestBody NewsRequest newsRequest) {
+        newsService.uploadNews(newsRequest);
+        return ResponseEntity.ok("콘텐츠 등록 완료");
+    }
+
+    @PostMapping("/contents/news/scheduled/{scheduledAt}")
+    @Operation(summary = "뉴스 콘텐츠 업로드 예약", description = "뉴스 콘텐츠 업로드 날짜를 설정하고 예약 합니다.")
+    public ResponseEntity<String> scheduleContentUpload(
+            @RequestBody NewsRequest newsRequest,
+            @PathVariable("scheduledAt") LocalDate scheduledAt) {
+        scheduledNewsService.scheduleUploadNews(newsRequest, scheduledAt);
+        return ResponseEntity.ok("콘텐츠 등록 완료");
+    }
+
+    @GetMapping("/contents/news/scheduled")
+    @Operation(summary = "예약 뉴스 업로드 리스트 조회", description = "페이지네이션 된 예약한 뉴스 업로드 리스트를 조회합니다.")
+    public ResponseEntity<Page<ScheduledNewsResponse>> getScheduledNewsList(
+            @PageableDefault Pageable pageable) {
+        Page<ScheduledNewsResponse> scheduledNewsPage = scheduledNewsService.getScheduledNewsList(pageable);
+        return ResponseEntity.ok(scheduledNewsPage);
+    }
+
+    @GetMapping("/contents/news")
+    @Operation(summary = "업로드 된 뉴스 콘텐츠 리스트 조회", description = "페이지네이션 된 업로드 뉴스 콘텐츠 리스트를 조회합니다.")
+    public ResponseEntity<Page<NewsResponse>> getNewsList(
+            @PageableDefault Pageable pageable
+    ){
+        Page<NewsResponse> newsResponsePage = newsService.getNewsList(pageable);
+        return ResponseEntity.ok(newsResponsePage);
+    }
+
+    @GetMapping("/contents/news/{newsId}")
+    @Operation(summary = "업로드 된 뉴스 콘텐츠 상세 데이터 조회", description = "ID 값으로 업로드 된 뉴스 콘텐츠 조회")
+    public ResponseEntity<NewsDetailResponse> getNewsDetail(@PathVariable("newsId") Integer newsId) {
+        NewsDetailResponse newsDetailResponse = newsService.getNewsDetail(newsId);
+        return ResponseEntity.ok(newsDetailResponse);
+
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/ContentController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/ContentController.java
@@ -112,28 +112,4 @@ public class ContentController {
         reviewService.reviewContent(reviewRequest, newsId);
         return ResponseEntity.ok("리뷰 등록 완료");
     }
-
-    @PostMapping("/news")
-    @Operation(summary = "뉴스 콘텐츠 즉시 업로드", description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다.")
-    public ResponseEntity<String> uploadNews(@RequestBody NewsRequest newsRequest) {
-        newsService.uploadNews(newsRequest);
-        return ResponseEntity.ok("콘텐츠 등록 완료");
-    }
-
-    @PostMapping("/news/scheduled/{scheduledAt}")
-    @Operation(summary = "뉴스 콘텐츠 업로드 예약",description = "뉴스 콘텐츠 업로드 날짜를 설정하고 예약 합니다.")
-    public ResponseEntity<String> scheduleContentUpload(
-        @RequestBody NewsRequest newsRequest,
-        @PathVariable("scheduledAt") LocalDate scheduledAt) {
-        scheduledNewsService.scheduleUploadNews(newsRequest, scheduledAt);
-        return ResponseEntity.ok("콘텐츠 등록 완료");
-    }
-
-    @GetMapping("/news/scheduled")
-    @Operation(summary = "예약 뉴스 업로드 리스트 조회", description = "페이지네이션 된 예약한 뉴스 업로드 리스트를 조회합니다.")
-    public ResponseEntity<Page<ScheduledNewsResponse>> getScheduledNewsList(
-            @PageableDefault Pageable pageable) {
-        Page<ScheduledNewsResponse> scheduledNewsPage = scheduledNewsService.getScheduledNewsList(pageable);
-        return ResponseEntity.ok(scheduledNewsPage);
-    }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionarySentenceRequest.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionarySentenceRequest.java
@@ -1,5 +1,8 @@
 package com.onedreamus.project.thisismoney.model.dto;
 
+import com.onedreamus.project.global.validator.ValidDictionarySentence;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,13 +12,18 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
+@ValidDictionarySentence
 public class DictionarySentenceRequest {
 
     private Long dictionaryId;
     private String dictionaryTerm;
     private String dictionaryDefinition;
     private String dictionaryDescription;
+
+    @NotBlank(message = "sentenceValue는 필수 값입니다.")
     private String sentenceValue;
+    @NotNull(message = "sentenceValue는 필수 값입니다.")
     private Integer startIdx;
+    @NotNull(message = "sentenceValue는 필수 값입니다.")
     private Integer endIdx;
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsRequest.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsRequest.java
@@ -1,6 +1,10 @@
 package com.onedreamus.project.thisismoney.model.dto;
 
 import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +16,20 @@ import lombok.Setter;
 @Setter
 public class NewsRequest {
 
+    @NotBlank(message = "뉴스 제목은 필수 값 입니다.")
     private String title; // 뉴스 제목
+
+    @NotBlank(message = "썸네일 URL은 필수 값 입니다.")
     private String thumbnailUrl; // 썸네일 URL
+
+    @NotBlank(message = "원본 링크는 필수 값 입니다.")
     private String originalLink; // 기사 원본 링크
+
+    @NotBlank(message = "에이전시 값은 필수 값 입니다.")
     private String newsAgency; // 뉴스 업로드한 에이전시
+
+    @Valid
+    @NotEmpty(message = "용어, 문장 값은 필수 입니다.")
     private List<DictionarySentenceRequest> dictionarySentenceList;
 
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsResponse.java
@@ -1,0 +1,33 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import com.onedreamus.project.thisismoney.model.entity.News;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class NewsResponse {
+
+    private Integer id;
+    private String title;
+    private String thumbnailUrl;
+    private LocalDateTime createdAt;
+    private String newsAgency;
+    private String link;
+
+    public static NewsResponse from(News news) {
+        return NewsResponse.builder()
+                .id(news.getId())
+                .title(news.getTitle())
+                .thumbnailUrl(news.getThumbnailUrl())
+                .createdAt(news.getCreatedAt())
+                .newsAgency(news.getNewsAgency())
+                .link(news.getLink())
+                .build();
+    }
+
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
@@ -17,7 +17,9 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -241,5 +243,10 @@ public class NewsService {
         }
 
         return sb.toString();
+    }
+
+    public Page<NewsResponse> getNewsList(Pageable pageable) {
+        return newsRepository.findAll(pageable)
+                .map(NewsResponse::from);
     }
 }


### PR DESCRIPTION
## Description
> issue : [DEV-254]
- 뉴스 리스트 조회 API 추가
    - 백오피스 전용으로 업로드 된 뉴스 리스트를 조회하는 API 추가
    - 기존에 동일한 API 가 있지만 역할 분리를 위해 추가
- 뉴스 콘텐츠 업로드 Validator 추가
    - validator를 사용하여 콘텐츠 업로드 시 요청 값 체크하여 오류 반환  

[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ