### PR TITLE
[DEV-254] refactor: 용어 정의에 하이라이트 마스킹 추가, 뉴스 리스트 정렬 반환

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/Dictionary.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/Dictionary.java
@@ -5,15 +5,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.websocket.server.ServerEndpoint;
+import lombok.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Builder
+@Setter
 @Table(name="dictionary")
 @Entity(name="Dictionary")
 public class Dictionary {

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/NewsRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/NewsRepository.java
@@ -1,10 +1,12 @@
 package com.onedreamus.project.thisismoney.repository;
 
+import aj.org.objectweb.asm.commons.Remapper;
 import com.onedreamus.project.thisismoney.model.entity.Content;
 import com.onedreamus.project.thisismoney.model.entity.News;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +23,6 @@ public interface NewsRepository extends JpaRepository<News, Integer> {
     );
 
     Optional<News> findFirstByOrderByCreatedAtDesc();
+
+    Page<News> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/ScheduledNewsRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/ScheduledNewsRepository.java
@@ -3,6 +3,9 @@ package com.onedreamus.project.thisismoney.repository;
 import com.onedreamus.project.thisismoney.model.entity.ScheduledNews;
 import java.time.LocalDate;
 import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +14,5 @@ public interface ScheduledNewsRepository extends JpaRepository<ScheduledNews, In
 
     Optional<ScheduledNews> findByScheduledAt(LocalDate now);
 
+    Page<ScheduledNews> findAllByOrderByScheduledAtAsc(Pageable pageable);
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
@@ -292,7 +292,7 @@ public class NewsService {
     }
 
     public Page<NewsResponse> getNewsList(Pageable pageable) {
-        return newsRepository.findAll(pageable)
+        return newsRepository.findAllByOrderByCreatedAtDesc(pageable)
                 .map(NewsResponse::from);
     }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
@@ -202,14 +202,14 @@ public class NewsService {
             Dictionary dictionary;
             // 기존 단어 재사용 하는 경우
             if (request.getDictionaryId() != null) {
-                dictionary = dictionaryService.getDictionaryById(
-                        request.getDictionaryId())
+                dictionary = dictionaryService.getDictionaryById(request.getDictionaryId())
                     .orElseThrow(() -> new DictionaryException(ErrorCode.DICTIONARY_NOT_EXIST));
 
             } else { // 새로운 용어를 등록하여 매핑하는 경우
                 // 새로운 용어 생성
+                String markedDefinition = addHighlightMarkDefinition(request.getDictionaryDefinition(), request.getDictionaryTerm());
                 dictionary = dictionaryService.saveNewDictionary(
-                    Dictionary.from(request.getDictionaryTerm(), request.getDictionaryDefinition(),
+                    Dictionary.from(request.getDictionaryTerm(), markedDefinition,
                         request.getDictionaryDescription()));
             }
 
@@ -225,6 +225,52 @@ public class NewsService {
         }
 
 
+    }
+
+    private String addHighlightMarkDefinition(String definition, String term){
+        char[] charArr = definition.toCharArray();
+        char[] termArr = term.toCharArray();
+
+        int startIdx = 0;
+        int endIdx = 0;
+        boolean find = true;
+
+        for (int i = 0; i < charArr.length; i++) {
+            if (charArr[i] != term.charAt(0)) {
+                continue;
+            }
+
+            boolean flag = true;
+            for (int j = 0; j < termArr.length; j++) {
+                if (charArr[i + j] != termArr[j]) {
+                    flag = false;
+                }
+            }
+            if (!flag) {
+                find = false;
+            }else {
+                startIdx = i;
+                endIdx = i + termArr.length - 1;
+                break;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (find) {
+            for (int i = 0; i < charArr.length; i++) {
+                if (i == startIdx) {
+                    sb.append("<mark>");
+                }
+
+                sb.append(charArr[i]);
+
+                if (i == endIdx) {
+                    sb.append("</mark>");
+                }
+            }
+        }
+
+        return sb.toString();
     }
 
     private String addHighlightMark(String sentence, int startIdx, int endIdx) {

--- a/src/main/java/com/onedreamus/project/thisismoney/service/ScheduledNewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/ScheduledNewsService.java
@@ -35,7 +35,7 @@ public class ScheduledNewsService {
     }
 
     public Page<ScheduledNewsResponse> getScheduledNewsList(Pageable pageable) {
-        return scheduledNewsRepository.findAll(pageable)
+        return scheduledNewsRepository.findAllByOrderByScheduledAtAsc(pageable)
                 .map(ScheduledNewsResponse::from);
     }
 }


### PR DESCRIPTION
## Description
> issue : [DEV-254]
- 새로 등록 된 용어 정의에 하이라이트 마킹 추가
- 뉴스 리스트 조회 시 최신 등록 순으로 정렬하여 반환
- 예약 뉴스 리스트 조회 시 업로드에 임박한 순으로 정렬하여 반환 

[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ