### PR TITLE
뉴스사 조회 및 이미지 관리(S3) 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 	implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
 
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 
 }
 

--- a/src/main/java/com/onedreamus/project/global/config/s3/S3Config.java
+++ b/src/main/java/com/onedreamus/project/global/config/s3/S3Config.java
@@ -1,0 +1,33 @@
+package com.onedreamus.project.global.config.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedreamus/project/global/exception/ErrorCode.java
@@ -47,7 +47,11 @@ public enum ErrorCode {
     WRONG_ANSWER_NOTE_NOT_EXIST(HttpStatus.NOT_FOUND, "오답노트에 존재하지 않는 용어입니다."),
 
     // Quiz
-    NOT_ENOUGH_DICTIONARY(HttpStatus.BAD_REQUEST, "핵심단어와 오답노트에 단어가 총 3개 이상 필요합니다.");
+    NOT_ENOUGH_DICTIONARY(HttpStatus.BAD_REQUEST, "핵심단어와 오답노트에 단어가 총 3개 이상 필요합니다."),
+
+    // S3
+    IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드에 실패했습니다."),
+    AWS_SDK_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 SDK 에러가 발생하여 정보를 처리할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/onedreamus/project/global/s3/ImageCategory.java
+++ b/src/main/java/com/onedreamus/project/global/s3/ImageCategory.java
@@ -1,0 +1,13 @@
+package com.onedreamus.project.global.s3;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageCategory {
+
+    THUMBNAIL("thumbnail");
+
+    private final String name;
+}

--- a/src/main/java/com/onedreamus/project/global/s3/S3Uploader.java
+++ b/src/main/java/com/onedreamus/project/global/s3/S3Uploader.java
@@ -1,0 +1,93 @@
+package com.onedreamus.project.global.s3;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.onedreamus.project.global.exception.ErrorCode;
+import com.onedreamus.project.thisismoney.exception.S3Exception;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucketname}")
+    private String bucket;
+
+    /**
+     * <p>S3 이미지 업로드</p>
+     * S3에 이미지 업로드 후, 이미지 URL 반환
+     * @param multipartFile
+     * @param imageCategory
+     * @return
+     */
+    public String uploadMultipartFileByStream(MultipartFile multipartFile, ImageCategory imageCategory) {
+
+        String filename = multipartFile.getOriginalFilename();
+        String newFilename = createFileName(filename, imageCategory);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(getContentType(filename));
+        metadata.setContentLength(multipartFile.getSize());
+
+        try {
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucket, newFilename, multipartFile.getInputStream(), metadata));
+        } catch (IOException e) {
+            throw new S3Exception(ErrorCode.IMAGE_UPLOAD_FAIL);
+        }
+
+        return amazonS3Client.getUrl(bucket, newFilename).toString();
+    }
+
+    /**
+     * <p>S3 이미지 삭제</p>
+     * @param fileName
+     */
+    public void deleteFile(String fileName) {
+        try {
+            amazonS3Client.deleteObject(bucket, fileName);
+            log.info(" S3 객체 삭제 : {}", fileName);
+        } catch (SdkClientException e) {
+            throw new S3Exception(ErrorCode.AWS_SDK_ERROR);
+        }
+    }
+
+    private String createFileName(String fileName, ImageCategory imageCategory) {
+        String random = UUID.randomUUID().toString();
+        return imageCategory.getName() + "-" + random + fileName;
+    }
+
+    private String getContentType(String filename) {
+        int idx = filename.lastIndexOf(".");
+        String extension = filename.substring(idx + 1);
+        return "image/" + extension;
+    }
+
+    private void deleteUploadedImageList(List<String> imageUrlList) {
+        for (String imageUrl : imageUrlList) {
+            deleteFile(getFileName(imageUrl));
+        }
+    }
+
+    @NotNull
+    public String getFileName(String imageUrl) {
+        return imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -1,6 +1,7 @@
 package com.onedreamus.project.thisismoney.controller;
 
 import com.onedreamus.project.thisismoney.model.dto.*;
+import com.onedreamus.project.thisismoney.service.AgencyService;
 import com.onedreamus.project.thisismoney.service.NewsService;
 import com.onedreamus.project.thisismoney.service.ScheduledNewsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,9 +11,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/back-office")
@@ -21,6 +24,7 @@ public class BackOfficeController {
 
     private final ScheduledNewsService scheduledNewsService;
     private final NewsService newsService;
+    private final AgencyService agencyService;
 
     @PostMapping("/contents/news")
     @Operation(summary = "뉴스 콘텐츠 즉시 업로드", description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다.")
@@ -60,5 +64,12 @@ public class BackOfficeController {
     public ResponseEntity<NewsDetailResponse> getNewsDetail(@PathVariable("newsId") Integer newsId) {
         NewsDetailResponse newsDetailResponse = newsService.getNewsDetail(newsId);
         return ResponseEntity.ok(newsDetailResponse);
+    }
+
+    @GetMapping("/agency/{keyword}")
+    @Operation(summary = "뉴스사 검색", description = "keyword를 포함하는 모든 뉴스사를 조회합니다.")
+    public ResponseEntity<List<AgencySearch>> searchAgency(@PathVariable("keeyword") String keyword) {
+        List<AgencySearch> agencySearches = agencyService.searchAgency(keyword);
+        return ResponseEntity.ok(agencySearches);
     }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -28,7 +28,7 @@ public class BackOfficeController {
 
     @PostMapping("/contents/news")
     @Operation(summary = "뉴스 콘텐츠 즉시 업로드", description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다.")
-    public ResponseEntity<String> uploadNews(@Valid @RequestBody NewsRequest newsRequest) {
+    public ResponseEntity<String> uploadNews(@Valid @ModelAttribute NewsRequest newsRequest) {
         newsService.uploadNews(newsRequest);
         return ResponseEntity.ok("콘텐츠 등록 완료");
     }
@@ -36,7 +36,7 @@ public class BackOfficeController {
     @PostMapping("/contents/news/scheduled/{scheduledAt}")
     @Operation(summary = "뉴스 콘텐츠 업로드 예약", description = "뉴스 콘텐츠 업로드 날짜를 설정하고 예약 합니다.")
     public ResponseEntity<String> scheduleContentUpload(
-            @Valid @RequestBody NewsRequest newsRequest,
+            @Valid @ModelAttribute NewsRequest newsRequest,
             @PathVariable("scheduledAt") LocalDate scheduledAt) {
         scheduledNewsService.scheduleUploadNews(newsRequest, scheduledAt);
         return ResponseEntity.ok("콘텐츠 등록 완료");

--- a/src/main/java/com/onedreamus/project/thisismoney/exception/S3Exception.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/exception/S3Exception.java
@@ -1,0 +1,10 @@
+package com.onedreamus.project.thisismoney.exception;
+
+import com.onedreamus.project.global.exception.CustomException;
+import com.onedreamus.project.global.exception.ErrorCode;
+
+public class S3Exception extends CustomException {
+    public S3Exception(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/converter/NewsRequestConverter.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/converter/NewsRequestConverter.java
@@ -2,33 +2,34 @@ package com.onedreamus.project.thisismoney.model.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedreamus.project.thisismoney.model.dto.NewsRequest;
+import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsRequest;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class NewsRequestConverter implements AttributeConverter<NewsRequest, String> {
+public class NewsRequestConverter implements AttributeConverter<ScheduledNewsRequest, String> {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public String convertToDatabaseColumn(NewsRequest newsRequest) {
-        if (newsRequest == null) {
+    public String convertToDatabaseColumn(ScheduledNewsRequest scheduledNewsRequest) {
+        if (scheduledNewsRequest == null) {
             return null;
         }
         try {
-            return objectMapper.writeValueAsString(newsRequest);
+            return objectMapper.writeValueAsString(scheduledNewsRequest);
         } catch (Exception e) {
             throw new IllegalArgumentException("Error converting NewsRequest to JSON string", e);
         }
     }
 
     @Override
-    public NewsRequest convertToEntityAttribute(String dbData) {
+    public ScheduledNewsRequest convertToEntityAttribute(String dbData) {
         if (dbData == null) {
             return null;
         }
         try {
-            return objectMapper.readValue(dbData, NewsRequest.class);
+            return objectMapper.readValue(dbData, ScheduledNewsRequest.class);
         } catch (Exception e) {
             throw new IllegalArgumentException("Error converting JSON string to NewsRequest", e);
         }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/AgencySearch.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/AgencySearch.java
@@ -1,0 +1,23 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import com.onedreamus.project.thisismoney.model.entity.Agency;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class AgencySearch {
+
+    private Integer id;
+    private String name;
+
+    public static AgencySearch from(Agency agency) {
+        return AgencySearch.builder()
+                .id(agency.getId())
+                .name(agency.getName())
+                .build();
+    }
+
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsRequest.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsRequest.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,8 +20,8 @@ public class NewsRequest {
     @NotBlank(message = "뉴스 제목은 필수 값 입니다.")
     private String title; // 뉴스 제목
 
-    @NotBlank(message = "썸네일 URL은 필수 값 입니다.")
-    private String thumbnailUrl; // 썸네일 URL
+
+    private MultipartFile thumbnailImage; // 썸네일 URL
 
     @NotBlank(message = "원본 링크는 필수 값 입니다.")
     private String originalLink; // 기사 원본 링크

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsRequest.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsRequest.java
@@ -1,0 +1,33 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ScheduledNewsRequest {
+
+    private String title; // 뉴스 제목
+    private String thumbnailUrl; // 썸네일 URL
+    private String originalLink; // 기사 원본 링크
+    private String newsAgency; // 뉴스 업로드한 에이전시
+    private List<DictionarySentenceRequest> dictionarySentenceList;
+
+    public static ScheduledNewsRequest from(NewsRequest newsRequest, String thumbnailUrl) {
+        return ScheduledNewsRequest.builder()
+                .title(newsRequest.getTitle())
+                .thumbnailUrl(thumbnailUrl)
+                .originalLink(newsRequest.getOriginalLink())
+                .newsAgency(newsRequest.getNewsAgency())
+                .dictionarySentenceList(newsRequest.getDictionarySentenceList())
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsResponse.java
@@ -16,13 +16,13 @@ import lombok.Setter;
 public class ScheduledNewsResponse {
 
     private Integer id;
-    private NewsRequest newsRequest;
+    private ScheduledNewsRequest newsRequest;
     private LocalDate scheduledAt;
 
     public static ScheduledNewsResponse from(ScheduledNews scheduledNews) {
         return ScheduledNewsResponse.builder()
             .id(scheduledNews.getId())
-            .newsRequest(scheduledNews.getNewsRequest())
+            .newsRequest(scheduledNews.getScheduledNewsRequest())
             .scheduledAt(scheduledNews.getScheduledAt())
             .build();
     }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/Agency.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/Agency.java
@@ -20,4 +20,10 @@ public class Agency {
 
     private String name;
 
+    public static Agency from(String name) {
+        return Agency.builder()
+                .name(name)
+                .build();
+    }
+
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/Agency.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/Agency.java
@@ -1,0 +1,23 @@
+package com.onedreamus.project.thisismoney.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class Agency {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/ScheduledNews.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/ScheduledNews.java
@@ -2,6 +2,7 @@ package com.onedreamus.project.thisismoney.model.entity;
 
 import com.onedreamus.project.thisismoney.model.converter.NewsRequestConverter;
 import com.onedreamus.project.thisismoney.model.dto.NewsRequest;
+import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -32,13 +33,13 @@ public class ScheduledNews {
     @Column(columnDefinition = "jsonb")
     @Convert(converter = NewsRequestConverter.class)
     @JdbcTypeCode(SqlTypes.JSON)  // Hibernate 6에 json 타입임을 알림
-    private NewsRequest newsRequest;
+    private ScheduledNewsRequest scheduledNewsRequest;
 
     private LocalDate scheduledAt; // 업로드 날짜.
 
-    public static ScheduledNews from(NewsRequest newsRequest, LocalDate scheduledAt) {
+    public static ScheduledNews from(ScheduledNewsRequest scheduledNewsRequest, LocalDate scheduledAt, String thumbnailUrl) {
         return ScheduledNews.builder()
-            .newsRequest(newsRequest)
+            .scheduledNewsRequest(scheduledNewsRequest)
             .scheduledAt(scheduledAt)
             .build();
     }

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/AgencyRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/AgencyRepository.java
@@ -1,0 +1,14 @@
+package com.onedreamus.project.thisismoney.repository;
+
+import com.onedreamus.project.thisismoney.model.dto.AgencySearch;
+import com.onedreamus.project.thisismoney.model.entity.Agency;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AgencyRepository extends JpaRepository<Agency, Integer> {
+
+    List<Agency> findByNameContaining(String keyword);
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/AgencyRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/AgencyRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface AgencyRepository extends JpaRepository<Agency, Integer> {
 
     List<Agency> findByNameContaining(String keyword);
+
+    boolean existsByName(String agencyName);
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/scheduler/ScheduledTasks.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/scheduler/ScheduledTasks.java
@@ -1,10 +1,14 @@
 package com.onedreamus.project.thisismoney.scheduler;
 
+import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsRequest;
+import com.onedreamus.project.thisismoney.model.entity.News;
 import com.onedreamus.project.thisismoney.model.entity.ScheduledNews;
 import com.onedreamus.project.thisismoney.service.NewsService;
 import com.onedreamus.project.thisismoney.service.ScheduledNewsService;
+
 import java.time.LocalDate;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -22,15 +26,23 @@ public class ScheduledTasks {
     public void uploadScheduledNews() {
         LocalDate now = LocalDate.now();
         Optional<ScheduledNews> scheduledNewsOptional =
-            scheduledNewsService.getScheduledNewsByScheduledAt(now);
+                scheduledNewsService.getScheduledNewsByScheduledAt(now);
         if (scheduledNewsOptional.isEmpty()) {
             log.info("[{} : 오늘 예약된 업로드 예정 뉴스 콘텐츠가 없습니다.]", now);
             return;
         }
 
         ScheduledNews scheduledNews = scheduledNewsOptional.get();
+        ScheduledNewsRequest scheduledNewsRequest = scheduledNews.getScheduledNewsRequest();
 
-        newsService.uploadNews(scheduledNews.getNewsRequest());
+        newsService.uploadNews(
+                News.from(
+                        scheduledNewsRequest.getTitle(),
+                        scheduledNewsRequest.getThumbnailUrl(),
+                        scheduledNewsRequest.getNewsAgency(),
+                        scheduledNewsRequest.getOriginalLink()),
+                scheduledNewsRequest.getDictionarySentenceList());
+
         log.info("[{} : 뉴스 콘테츠 업로드 완료]", now);
         scheduledNewsService.deleteScheduledNews(scheduledNews);
     }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/AgencyService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/AgencyService.java
@@ -1,0 +1,21 @@
+package com.onedreamus.project.thisismoney.service;
+
+import com.onedreamus.project.thisismoney.model.dto.AgencySearch;
+import com.onedreamus.project.thisismoney.repository.AgencyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AgencyService {
+
+    private final AgencyRepository agencyRepository;
+
+    public List<AgencySearch> searchAgency(String keyword) {
+        return agencyRepository.findByNameContaining(keyword).stream()
+                .map(AgencySearch::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/service/AgencyService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/AgencyService.java
@@ -1,7 +1,9 @@
 package com.onedreamus.project.thisismoney.service;
 
 import com.onedreamus.project.thisismoney.model.dto.AgencySearch;
+import com.onedreamus.project.thisismoney.model.entity.Agency;
 import com.onedreamus.project.thisismoney.repository.AgencyRepository;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,5 +19,12 @@ public class AgencyService {
         return agencyRepository.findByNameContaining(keyword).stream()
                 .map(AgencySearch::from)
                 .toList();
+    }
+
+    public void saveIfNotExist(String agencyName) {
+        boolean isExist = agencyRepository.existsByName(agencyName);
+        if (!isExist) {
+            agencyRepository.save(Agency.from(agencyName));
+        }
     }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
@@ -34,6 +34,7 @@ public class NewsService {
     private final DictionarySentenceRepository dictionarySentenceRepository;
     private final UsersStudyDaysRepository usersStudyDaysRepository;
     private final DictionaryService dictionaryService;
+    private final AgencyService agencyService;
 
     public CursorResult<NewsListResponse> getNewList(Integer cursor, Integer size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
@@ -197,6 +198,9 @@ public class NewsService {
             newsRequest.getThumbnailUrl(),
             newsRequest.getNewsAgency(),
             newsRequest.getOriginalLink()));
+
+        // 기존에 없던 뉴스사이면 저장
+        agencyService.saveIfNotExist(newsRequest.getNewsAgency());
 
         for (DictionarySentenceRequest request : newsRequest.getDictionarySentenceList()) {
             Dictionary dictionary;

--- a/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
@@ -1,6 +1,8 @@
 package com.onedreamus.project.thisismoney.service;
 
 import com.onedreamus.project.global.exception.ErrorCode;
+import com.onedreamus.project.global.s3.ImageCategory;
+import com.onedreamus.project.global.s3.S3Uploader;
 import com.onedreamus.project.global.util.NumberFormatter;
 import com.onedreamus.project.thisismoney.exception.DictionaryException;
 import com.onedreamus.project.thisismoney.exception.NewsException;
@@ -35,6 +37,7 @@ public class NewsService {
     private final UsersStudyDaysRepository usersStudyDaysRepository;
     private final DictionaryService dictionaryService;
     private final AgencyService agencyService;
+    private final S3Uploader s3Uploader;
 
     public CursorResult<NewsListResponse> getNewList(Integer cursor, Integer size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
@@ -184,6 +187,7 @@ public class NewsService {
     }
 
 
+
     /**
      * <p>뉴스 콘텐츠 즉시 등록</p>
      *
@@ -191,45 +195,54 @@ public class NewsService {
      */
     @Transactional
     public void uploadNews(NewsRequest newsRequest) {
-
-        // 새로운 뉴스 콘텐츠 저장
+        String thumbnailUrl = s3Uploader.uploadMultipartFileByStream(newsRequest.getThumbnailImage(), ImageCategory.THUMBNAIL);
         News newNews = newsRepository.save(News.from(
-            newsRequest.getTitle(),
-            newsRequest.getThumbnailUrl(),
-            newsRequest.getNewsAgency(),
-            newsRequest.getOriginalLink()));
+                newsRequest.getTitle(),
+                thumbnailUrl,
+                newsRequest.getNewsAgency(),
+                newsRequest.getOriginalLink()));
+
+        uploadNews(newNews, newsRequest.getDictionarySentenceList());
+    }
+
+    /**
+     * <p>뉴스 콘텐츠 등록</p>
+     * @param news
+     * @param dictionarySentenceRequests
+     */
+    public void uploadNews(News news, List<DictionarySentenceRequest> dictionarySentenceRequests) {
 
         // 기존에 없던 뉴스사이면 저장
-        agencyService.saveIfNotExist(newsRequest.getNewsAgency());
+        agencyService.saveIfNotExist(news.getNewsAgency());
 
-        for (DictionarySentenceRequest request : newsRequest.getDictionarySentenceList()) {
+        for (DictionarySentenceRequest request : dictionarySentenceRequests) {
             Dictionary dictionary;
             // 기존 단어 재사용 하는 경우
             if (request.getDictionaryId() != null) {
                 dictionary = dictionaryService.getDictionaryById(request.getDictionaryId())
-                    .orElseThrow(() -> new DictionaryException(ErrorCode.DICTIONARY_NOT_EXIST));
+                        .orElseThrow(() -> new DictionaryException(ErrorCode.DICTIONARY_NOT_EXIST));
 
             } else { // 새로운 용어를 등록하여 매핑하는 경우
                 // 새로운 용어 생성
                 String markedDefinition = addHighlightMarkDefinition(request.getDictionaryDefinition(), request.getDictionaryTerm());
                 dictionary = dictionaryService.saveNewDictionary(
-                    Dictionary.from(request.getDictionaryTerm(), markedDefinition,
-                        request.getDictionaryDescription()));
+                        Dictionary.from(request.getDictionaryTerm(), markedDefinition,
+                                request.getDictionaryDescription()));
             }
 
             // 하이라이팅 필요한 부분에 <mark> 표시 추가
             String markedSentence = addHighlightMark(
-                request.getSentenceValue(), request.getStartIdx(), request.getEndIdx());
+                    request.getSentenceValue(), request.getStartIdx(), request.getEndIdx());
 
             // 문장 저장
-            Sentence newSentence = sentenceRepository.save(Sentence.from(markedSentence, newNews));
+            Sentence newSentence = sentenceRepository.save(Sentence.from(markedSentence, news));
 
             // 용어-문장 저장
             dictionarySentenceRepository.save(DictionarySentence.from(dictionary, newSentence));
+
         }
-
-
     }
+
 
     private String addHighlightMarkDefinition(String definition, String term){
         char[] charArr = definition.toCharArray();

--- a/src/main/java/com/onedreamus/project/thisismoney/service/ScheduledNewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/ScheduledNewsService.java
@@ -1,6 +1,9 @@
 package com.onedreamus.project.thisismoney.service;
 
+import com.onedreamus.project.global.s3.ImageCategory;
+import com.onedreamus.project.global.s3.S3Uploader;
 import com.onedreamus.project.thisismoney.model.dto.NewsRequest;
+import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsRequest;
 import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsResponse;
 import com.onedreamus.project.thisismoney.model.entity.ScheduledNews;
 import com.onedreamus.project.thisismoney.repository.ScheduledNewsRepository;
@@ -20,13 +23,16 @@ import org.springframework.stereotype.Service;
 public class ScheduledNewsService {
 
     private final ScheduledNewsRepository scheduledNewsRepository;
+    private final S3Uploader s3Uploader;
 
     /**
      * <p>예약 뉴스 콘텐츠 등록</p>
      * 매일 새벽 6시에 업로드 되도록 설정됨.
      */
     public void scheduleUploadNews(NewsRequest newsRequest, LocalDate scheduledAt) {
-        scheduledNewsRepository.save(ScheduledNews.from(newsRequest, scheduledAt));
+        String thumbnailUrl = s3Uploader.uploadMultipartFileByStream(newsRequest.getThumbnailImage(), ImageCategory.THUMBNAIL);
+        ScheduledNewsRequest scheduledNewsRequest = ScheduledNewsRequest.from(newsRequest, thumbnailUrl);
+        scheduledNewsRepository.save(ScheduledNews.from(scheduledNewsRequest, scheduledAt, thumbnailUrl));
     }
 
 


### PR DESCRIPTION
## Description
> issue : [DEV-254]
- 기존에 등록된 뉴스사는 조회가 가능하도록 API 추가
- Goolge 드라이브의 이미지를 사용하면서 권한 문제로 이미지 노출이 안되는 문제가 발생
    - 이미지 URL 을 받아 관리하던 방법에서 직접 이미지를 S3에 업로드하여 URL을 받아 관리하는 방식으로 수정