### PR TITLE
[DEV-254] fix : 업로드 예약된 뉴스 업로드 시 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/scheduler/ScheduledTasks.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/scheduler/ScheduledTasks.java
@@ -22,7 +22,7 @@ public class ScheduledTasks {
     private final NewsService newsService;
     private final ScheduledNewsService scheduledNewsService;
 
-    @Scheduled(cron = "0 0 6 * * ?")
+    @Scheduled(cron = "0 0 10 * * ?")
     public void uploadScheduledNews() {
         LocalDate now = LocalDate.now();
         Optional<ScheduledNews> scheduledNewsOptional =
@@ -35,12 +35,8 @@ public class ScheduledTasks {
         ScheduledNews scheduledNews = scheduledNewsOptional.get();
         ScheduledNewsRequest scheduledNewsRequest = scheduledNews.getScheduledNewsRequest();
 
-        newsService.uploadNews(
-                News.from(
-                        scheduledNewsRequest.getTitle(),
-                        scheduledNewsRequest.getThumbnailUrl(),
-                        scheduledNewsRequest.getNewsAgency(),
-                        scheduledNewsRequest.getOriginalLink()),
+        newsService.uploadScheduledNews(
+                scheduledNewsRequest,
                 scheduledNewsRequest.getDictionarySentenceList());
 
         log.info("[{} : 뉴스 콘테츠 업로드 완료]", now);


### PR DESCRIPTION
## Description
> issue : [DEV-254]
- 업로드 예약된 뉴스 업로드 시 News 객체를 저장하지 않고 Sentence 엔티티와 연관 관계를 맵핑하려고 해서 오류 발생
- 뉴스 콘텐츠 업로드 전 News 객체를 먼저 저장할 수 있도록 수정

[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ