### PR TITLE
[DEV-267] feat : 학습 상태 조회 및 학습 상태 수정 API 추가

### DIFF
--- a/src/main/java/com/onedreamus/project/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/onedreamus/project/global/config/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
         "/v1/user/logout", "/v1/note/**", "/v1/quiz/**", "/v1/users/quiz/first-attempt",
         "/v1/contents/news/{newsId}/users",
         "/v1/users/study-days/count",
+            "/v1/missions/**"
 
     };
 

--- a/src/main/java/com/onedreamus/project/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedreamus/project/global/exception/ErrorCode.java
@@ -51,7 +51,11 @@ public enum ErrorCode {
 
     // S3
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드에 실패했습니다."),
-    AWS_SDK_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 SDK 에러가 발생하여 정보를 처리할 수 없습니다.");
+    AWS_SDK_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 SDK 에러가 발생하여 정보를 처리할 수 없습니다.")
+
+    // Mission
+    , MISSING_DATE_OR_MONTH_PARAM(HttpStatus.BAD_REQUEST, "'date' 또는 'month' 값이 필요합니다.")
+    , INVALID_MONTH_FORMAT(HttpStatus.BAD_REQUEST, "'month' 형식이 잘못되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/MissionController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/MissionController.java
@@ -1,0 +1,52 @@
+package com.onedreamus.project.thisismoney.controller;
+
+import com.onedreamus.project.thisismoney.model.dto.ContinuousDaysResponse;
+import com.onedreamus.project.thisismoney.model.dto.CustomUserDetails;
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusResponse;
+import com.onedreamus.project.thisismoney.service.MissionService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+@RestController
+@RequestMapping("/v1/missions")
+@RequiredArgsConstructor
+public class MissionController {
+
+    private final MissionService missionService;
+
+    @GetMapping("/status")
+    @Operation(summary = "미션 상태 조회", description = "월 단위 또는 일 단위로 미션 상태를 조회합니다.")
+    public ResponseEntity<MissionStatusResponse> getMonthlyMissionStatus(
+            @RequestParam(required = false, value = "date") LocalDate date,
+            @RequestParam(required = false, value = "month") YearMonth month,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MissionStatusResponse missionStatusResponse =
+                missionService.getMissionStatus(userDetails.getUser(), date, month);
+        return ResponseEntity.ok(missionStatusResponse);
+    }
+
+    @GetMapping("/status/continuous-days")
+    @Operation(summary = "연속 학습 일수 조회", description = "연속 학습 일수를 조회합니다.")
+    public ResponseEntity<ContinuousDaysResponse> getContinuousDays(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        ContinuousDaysResponse continuousDaysResponse = missionService.getContinuousDays(userDetails.getUser(), LocalDate.now());
+        return ResponseEntity.ok(continuousDaysResponse);
+    }
+
+    @PostMapping("/status/news-learn")
+    @Operation(summary = "뉴스 학습 상태 수정", description = "뉴스 학습 상태를 true로 변경합니다.")
+    public ResponseEntity<String> updateNewsLearnMission(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        missionService.updateNewsLearnStatus(userDetails.getUser());
+        return ResponseEntity.ok("학습 상태 수정 성공");
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/exception/MissionException.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/exception/MissionException.java
@@ -1,0 +1,10 @@
+package com.onedreamus.project.thisismoney.exception;
+
+import com.onedreamus.project.global.exception.CustomException;
+import com.onedreamus.project.global.exception.ErrorCode;
+
+public class MissionException extends CustomException {
+    public MissionException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ContinuousDaysResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ContinuousDaysResponse.java
@@ -1,0 +1,14 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Getter
+public class ContinuousDaysResponse {
+
+    private Integer continuousDays;
+
+
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/DailyMissionDetail.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/DailyMissionDetail.java
@@ -1,0 +1,23 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class DailyMissionDetail {
+
+    private LocalDate date;
+    private MissionStatusDto missionStatus;
+
+    public static DailyMissionDetail from(LocalDate date, MissionStatusDto missionStatusDto) {
+        return DailyMissionDetail.builder()
+                .date(date)
+                .missionStatus(missionStatusDto)
+                .build();
+    }
+
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/MissionStatusDto.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/MissionStatusDto.java
@@ -1,0 +1,21 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MissionStatusDto {
+
+    private Boolean news;
+    private Boolean quiz;
+
+    public static MissionStatusDto from(boolean newsLearnStatus, boolean quizSolveStatus){
+        return MissionStatusDto.builder()
+                .news(newsLearnStatus)
+                .quiz(quizSolveStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/MissionStatusResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/MissionStatusResponse.java
@@ -1,0 +1,15 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class MissionStatusResponse {
+
+    private Object data;
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/MonthlyMissionStatus.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/MonthlyMissionStatus.java
@@ -1,0 +1,23 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class MonthlyMissionStatus {
+
+    private List<DailyMissionDetail> dailyMissionDetails;
+
+    public static MonthlyMissionStatus from(List<DailyMissionDetail> dailyMissionDetails) {
+        return MonthlyMissionStatus.builder()
+                .dailyMissionDetails(dailyMissionDetails)
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/Mission.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/Mission.java
@@ -1,0 +1,39 @@
+package com.onedreamus.project.thisismoney.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Users user;
+
+    private Boolean newsLearnStatus;
+    private Boolean quizSolveStatus;
+
+    private LocalDate date;
+    private int continuousDays;
+
+    public static Mission from(Users user, int continuousDays){
+        return Mission.builder()
+                .user(user)
+                .newsLearnStatus(false)
+                .quizSolveStatus(false)
+                .date(LocalDate.now())
+                .continuousDays(continuousDays)
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/MissionRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/MissionRepository.java
@@ -1,0 +1,18 @@
+package com.onedreamus.project.thisismoney.repository;
+
+import com.onedreamus.project.thisismoney.model.entity.Mission;
+import com.onedreamus.project.thisismoney.model.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Integer> {
+
+    Optional<Mission> findByUserAndDate(Users user, LocalDate now);
+
+    List<Mission> findByUserAndDateBetween(Users user, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/service/DailyMissionRetriever.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/DailyMissionRetriever.java
@@ -1,0 +1,39 @@
+package com.onedreamus.project.thisismoney.service;
+
+import com.onedreamus.project.thisismoney.model.dto.DailyMissionDetail;
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusDto;
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusResponse;
+import com.onedreamus.project.thisismoney.model.entity.Mission;
+import com.onedreamus.project.thisismoney.model.entity.Users;
+import com.onedreamus.project.thisismoney.repository.MissionRepository;
+import com.onedreamus.project.thisismoney.service.impl.MissionRetriever;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DailyMissionRetriever implements MissionRetriever {
+
+    private final MissionRepository missionRepository;
+
+    @Override
+    public MissionStatusResponse retrieve(Users user, LocalDate date) {
+        MissionStatusDto missionStatusDto = missionRepository
+                .findByUserAndDate(user, date)
+                .map(mission -> MissionStatusDto.from(mission.getNewsLearnStatus(), mission.getQuizSolveStatus()))
+                .orElse(MissionStatusDto.from(false, false));
+
+        return new MissionStatusResponse(missionStatusDto);
+    }
+
+    @Override
+    public MissionStatusResponse retrieve(Users user, YearMonth yearMonth) {
+        throw new UnsupportedOperationException("일별 미션 상태 조회 retrieval 은 YearMonth 를 지원한지 않습니다.");
+
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/service/MissionService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/MissionService.java
@@ -1,0 +1,95 @@
+package com.onedreamus.project.thisismoney.service;
+
+import com.onedreamus.project.global.exception.ErrorCode;
+import com.onedreamus.project.thisismoney.exception.MissionException;
+import com.onedreamus.project.thisismoney.model.dto.ContinuousDaysResponse;
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusResponse;
+import com.onedreamus.project.thisismoney.model.dto.MonthlyMissionStatus;
+import com.onedreamus.project.thisismoney.model.entity.Mission;
+import com.onedreamus.project.thisismoney.model.entity.Users;
+import com.onedreamus.project.thisismoney.repository.MissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+
+    private final MissionRepository missionRepository;
+    private final DailyMissionRetriever dailyMissionRetriever;
+    private final MonthlyMissionRetriever monthlyMissionRetriever;
+
+    /**
+     * <p>뉴스 학습 상태 업데이트</p>
+     * 뉴스 학습 상태를 true로 수정한다.
+     *
+     * @param user
+     */
+    @Transactional
+    public void updateNewsLearnStatus(Users user) {
+        Mission mission = missionRepository.findByUserAndDate(user, LocalDate.now())
+                .orElseGet(() -> {
+                    int continuousDays = getContinuousDays(user, LocalDate.now()).getContinuousDays();
+                    return Mission.from(user, continuousDays);
+                });
+
+        // 이미 뉴스 학습을 한 경우
+        if (mission.getNewsLearnStatus()) {
+            return;
+        }
+
+        mission.setNewsLearnStatus(true);
+        missionRepository.save(mission);
+    }
+
+    /**
+     * <p>퀴즈 풀이 상태 업데이트</p>
+     * 퀴즈 풀이 상태를 true로 수정한다.
+     *
+     * @param user
+     */
+    @Transactional
+    public void updateQuizSolveStatus(Users user) {
+        Mission mission = missionRepository.findByUserAndDate(user, LocalDate.now())
+                .orElseGet(() -> {
+                    int continuousDays = getContinuousDays(user, LocalDate.now()).getContinuousDays();
+                    return Mission.from(user, continuousDays);
+                });
+
+        // 이미 퀴즈 풀이를 한 경우
+        if (mission.getQuizSolveStatus()) {
+            return;
+        }
+
+        mission.setQuizSolveStatus(true);
+        missionRepository.save(mission);
+    }
+
+    @Transactional
+    public ContinuousDaysResponse getContinuousDays(Users user, LocalDate now) {
+        Optional<Mission> previousMission = missionRepository.findByUserAndDate(user, now.minusDays(1));
+        int continuousDays = previousMission
+                .map(mission -> mission.getContinuousDays() + 1)
+                .orElse(1);
+        return new ContinuousDaysResponse(continuousDays);
+    }
+
+    public MissionStatusResponse getMissionStatus(Users user, LocalDate date, YearMonth month) {
+        if (date != null) {
+            return dailyMissionRetriever.retrieve(user, date);
+        }
+        if (month != null) {
+            return monthlyMissionRetriever.retrieve(user, month);
+        }
+
+        throw new MissionException(ErrorCode.MISSING_DATE_OR_MONTH_PARAM);
+    }
+
+
+}
+

--- a/src/main/java/com/onedreamus/project/thisismoney/service/MonthlyMissionRetriever.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/MonthlyMissionRetriever.java
@@ -1,0 +1,58 @@
+package com.onedreamus.project.thisismoney.service;
+
+import com.onedreamus.project.thisismoney.model.dto.DailyMissionDetail;
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusDto;
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusResponse;
+import com.onedreamus.project.thisismoney.model.dto.MonthlyMissionStatus;
+import com.onedreamus.project.thisismoney.model.entity.Mission;
+import com.onedreamus.project.thisismoney.model.entity.Users;
+import com.onedreamus.project.thisismoney.repository.MissionRepository;
+import com.onedreamus.project.thisismoney.service.impl.MissionRetriever;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyMissionRetriever implements MissionRetriever {
+
+    private final MissionRepository missionRepository;
+
+    @Override
+    public MissionStatusResponse retrieve(Users user, LocalDate date) {
+        throw new UnsupportedOperationException("월별 미션 상태 조회 retrieval은 LocalDate를 지원한지 않습니다.");
+    }
+
+    @Override
+    public MissionStatusResponse retrieve(Users user, YearMonth yearMonth) {
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        Map<LocalDate, Mission> missionMap = missionRepository.findByUserAndDateBetween(user, startDate, endDate).stream()
+                .collect(Collectors.toMap(Mission::getDate, Function.identity()));
+
+        List<DailyMissionDetail> dailyMissionDetails = new ArrayList<>();
+        for (int day = 0; day < endDate.getDayOfMonth(); day++) {
+            LocalDate date = startDate.plusDays(day);
+            MissionStatusDto missionStatusDto = MissionStatusDto.from(false, false);
+
+            Mission mission = missionMap.get(date);
+            if (mission != null) {
+                missionStatusDto.setQuiz(mission.getQuizSolveStatus());
+                missionStatusDto.setNews(mission.getNewsLearnStatus());
+            }
+
+            dailyMissionDetails.add(DailyMissionDetail.from(date, missionStatusDto));
+        }
+
+        return new MissionStatusResponse(MonthlyMissionStatus.from(dailyMissionDetails));
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/service/QuizService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/QuizService.java
@@ -24,6 +24,7 @@ public class QuizService {
     private final ScrapService scrapService;
     private final DictionaryService dictionaryService;
     private final UserService userService;
+    private final MissionService missionService;
 
 
     // 방법 1 : 앱에서 중복 처리 -> 처리 복잡, 단일 쿼리가 많아짐
@@ -203,6 +204,9 @@ public class QuizService {
             user.setQuizAttempt(true);
             userService.saveUser(user);
         }
+
+        // 퀴즈 미션 상태 수정
+        missionService.updateQuizSolveStatus(user);
 
         return QuizResultResponse.from(totalGraduation, totalWrong, accuracyRate, resultDetails);
     }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/impl/MissionRetriever.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/impl/MissionRetriever.java
@@ -1,0 +1,13 @@
+package com.onedreamus.project.thisismoney.service.impl;
+
+import com.onedreamus.project.thisismoney.model.dto.MissionStatusResponse;
+import com.onedreamus.project.thisismoney.model.entity.Users;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+public interface MissionRetriever {
+    MissionStatusResponse retrieve(Users user, LocalDate date);
+
+    MissionStatusResponse retrieve(Users user, YearMonth yearMonth);
+}


### PR DESCRIPTION
## Description
> issue : [DEV-267]
- 학습 상태 조회(잔디심기) API 추가
- 퀴즈 풀이를 완료하면 '퀴즈 풀이 미션' 상태 true 로 변경
- 학습 완료 시 유저의 경우만 '뉴스 학습 미션 ' 상태 true로 변경 할 수 있도록 API 추가
- 연속 학습 일 수를 확인할 수 있는 API 추가

[DEV-267]: https://6bit.atlassian.net/browse/DEV-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ