### PR TITLE
feat : 예약 업로드된 뉴스 콘텐츠 상세 데이터 조회 API 추가

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -74,6 +74,14 @@ public class BackOfficeController {
         return ResponseEntity.ok(newsDetailResponse);
     }
 
+    @GetMapping("/contents/news/scheduled/{scheduledNewsId}")
+    @Operation(summary = "업로드 된 뉴스 콘텐츠 상세 데이터 조회", description = "ID 값으로 업로드 된 뉴스 콘텐츠 조회")
+    public ResponseEntity<ScheduledNewsDetailResponse> getScheduledNewsDetail(
+            @PathVariable("scheduledNewsId") Integer newsId) {
+        ScheduledNewsDetailResponse scheduledNewsDetail = scheduledNewsService.getScheduledNewsDetail(newsId);
+        return ResponseEntity.ok(scheduledNewsDetail);
+    }
+
     @GetMapping("/agency/{keyword}")
     @Operation(summary = "뉴스사 검색", description = "keyword를 포함하는 모든 뉴스사를 조회합니다.")
     public ResponseEntity<List<AgencySearch>> searchAgency(

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -70,7 +70,7 @@ public class BackOfficeController {
     @Operation(summary = "업로드 된 뉴스 콘텐츠 상세 데이터 조회", description = "ID 값으로 업로드 된 뉴스 콘텐츠 조회")
     public ResponseEntity<NewsDetailResponse> getNewsDetail(
         @PathVariable("newsId") Integer newsId) {
-        NewsDetailResponse newsDetailResponse = newsService.getNewsDetail(newsId);
+        NewsDetailResponse newsDetailResponse = newsService.getNewsDetailWithoutViewIncrease(newsId);
         return ResponseEntity.ok(newsDetailResponse);
     }
 

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionaryDescriptionDto.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionaryDescriptionDto.java
@@ -28,4 +28,14 @@ public class DictionaryDescriptionDto {
                 .build();
     }
 
+    public static DictionaryDescriptionDto from(DictionarySentenceRequest request) {
+        return DictionaryDescriptionDto.builder()
+                .sentence(request.getSentenceValue())
+                .definition(request.getDictionaryDefinition())
+                .description(request.getDictionaryDescription())
+                .dictionaryId(request.getDictionaryId())
+                .term(request.getDictionaryTerm())
+                .build();
+    }
+
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionaryDescriptionDto.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionaryDescriptionDto.java
@@ -18,24 +18,25 @@ public class DictionaryDescriptionDto {
     private Long dictionaryId;
     private String term;
 
-    public static DictionaryDescriptionDto from(String sentence, Dictionary dictionary) {
+    private static DictionaryDescriptionDto create(String sentence, String description, String definition, Long dictionaryId, String term) {
         return DictionaryDescriptionDto.builder()
                 .sentence(sentence)
-                .definition(dictionary.getDefinition())
-                .description(dictionary.getDescription())
-                .dictionaryId(dictionary.getId())
-                .term(dictionary.getTerm())
+                .description(description)
+                .definition(definition)
+                .term(term)
+                .dictionaryId(dictionaryId)
                 .build();
     }
 
+    public static DictionaryDescriptionDto from(String sentence, Dictionary dictionary) {
+        return create(sentence, dictionary.getDescription(),
+                dictionary.getDefinition(), dictionary.getId(), dictionary.getTerm());
+    }
+
     public static DictionaryDescriptionDto from(DictionarySentenceRequest request) {
-        return DictionaryDescriptionDto.builder()
-                .sentence(request.getSentenceValue())
-                .definition(request.getDictionaryDefinition())
-                .description(request.getDictionaryDescription())
-                .dictionaryId(request.getDictionaryId())
-                .term(request.getDictionaryTerm())
-                .build();
+        return create(request.getSentenceValue(), request.getDictionaryDescription(),
+                request.getDictionaryDefinition(), request.getDictionaryId(),
+                request.getDictionaryTerm());
     }
 
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
@@ -1,0 +1,44 @@
+package com.onedreamus.project.thisismoney.model.dto;
+
+import com.onedreamus.project.thisismoney.model.entity.News;
+import com.onedreamus.project.thisismoney.model.entity.ScheduledNews;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class ScheduledNewsDetailResponse {
+
+
+    private String title;
+    private String newsAgency; // 언론사
+    private String fullSentence; // 전체 내용 -> 각 문장들을 함친 내용
+    private String link; // 원문 링크
+    private List<DictionaryDescriptionDto> descriptions; // 각 문장에 대한 설명
+    private LocalDate scheduledAt;
+
+    public static ScheduledNewsDetailResponse from(ScheduledNews scheduledNews) {
+        ScheduledNewsRequest request = scheduledNews.getScheduledNewsRequest();
+
+        return ScheduledNewsDetailResponse.builder()
+                .title(request.getTitle())
+                .newsAgency(request.getNewsAgency())
+                .fullSentence(request.getDictionarySentenceList().stream()
+                        .map(DictionarySentenceRequest::getSentenceValue)
+                        .collect(Collectors.joining()))
+                .descriptions(request.getDictionarySentenceList().stream()
+                        .map(DictionaryDescriptionDto::from)
+                        .toList())
+                .link(request.getOriginalLink())
+                .scheduledAt(scheduledNews.getScheduledAt())
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/NewsView.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/NewsView.java
@@ -35,4 +35,8 @@ public class NewsView {
             .viewDate(LocalDateTime.now())
             .build();
     }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/ScheduledNewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/ScheduledNewsService.java
@@ -1,16 +1,19 @@
 package com.onedreamus.project.thisismoney.service;
 
+import com.onedreamus.project.global.exception.ErrorCode;
 import com.onedreamus.project.global.s3.ImageCategory;
 import com.onedreamus.project.global.s3.S3Uploader;
-import com.onedreamus.project.thisismoney.model.dto.DictionarySentenceRequest;
-import com.onedreamus.project.thisismoney.model.dto.NewsRequest;
-import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsRequest;
-import com.onedreamus.project.thisismoney.model.dto.ScheduledNewsResponse;
+import com.onedreamus.project.thisismoney.exception.NewsException;
+import com.onedreamus.project.thisismoney.model.dto.*;
+import com.onedreamus.project.thisismoney.model.entity.DictionarySentence;
 import com.onedreamus.project.thisismoney.model.entity.ScheduledNews;
 import com.onedreamus.project.thisismoney.repository.ScheduledNewsRepository;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -31,13 +34,13 @@ public class ScheduledNewsService {
      * 매일 새벽 6시에 업로드 되도록 설정됨.
      */
     public void scheduleUploadNews(NewsRequest newsRequest, MultipartFile thumbnailImage,
-        List<DictionarySentenceRequest> dictionarySentenceRequests, LocalDate scheduledAt) {
+                                   List<DictionarySentenceRequest> dictionarySentenceRequests, LocalDate scheduledAt) {
         String thumbnailUrl = s3Uploader.uploadMultipartFileByStream(
-            thumbnailImage, ImageCategory.THUMBNAIL);
+                thumbnailImage, ImageCategory.THUMBNAIL);
         ScheduledNewsRequest scheduledNewsRequest = ScheduledNewsRequest.from(newsRequest,
-            thumbnailUrl, dictionarySentenceRequests);
+                thumbnailUrl, dictionarySentenceRequests);
         scheduledNewsRepository.save(
-            ScheduledNews.from(scheduledNewsRequest, scheduledAt, thumbnailUrl));
+                ScheduledNews.from(scheduledNewsRequest, scheduledAt, thumbnailUrl));
     }
 
 
@@ -47,10 +50,24 @@ public class ScheduledNewsService {
 
     public Page<ScheduledNewsResponse> getScheduledNewsList(Pageable pageable) {
         return scheduledNewsRepository.findAllByOrderByScheduledAtAsc(pageable)
-            .map(ScheduledNewsResponse::from);
+                .map(ScheduledNewsResponse::from);
     }
 
     public void deleteScheduledNews(ScheduledNews scheduledNews) {
         scheduledNewsRepository.delete(scheduledNews);
+    }
+
+    /**
+     * <p>[업로드 예약 콘텐츠 상세 조회]</p>
+     * 업로드 예약 된 콘텐츠의 상세 데이터를 조회합니다.
+     *
+     * @param scheduledNewsId
+     * @return
+     */
+    public ScheduledNewsDetailResponse getScheduledNewsDetail(Integer scheduledNewsId) {
+        ScheduledNews scheduledNews = scheduledNewsRepository.findById(scheduledNewsId)
+                .orElseThrow(() -> new NewsException(ErrorCode.CONTENT_NOT_EXIST));
+
+        return ScheduledNewsDetailResponse.from(scheduledNews);
     }
 }


### PR DESCRIPTION
## Description
> issue : [DEV-254]
- 백오피스에서 업로드 예약된 뉴스 콘텐츠의 상세데이터를 조회하는 API 추가

> 코드 리팩토링
- 객체 생성을 static from() 메소드로 생성하도록 수정 -> 코드 간결화
- 서비스에서 사용하던 뉴스 상세 데이터 조회 메소드를 백오피스에서 사용할 경우 increaseViewCount() 가 발생하는 문제 
    - 공통 로직을 buildNewsDetailResponse() 메소드로 분리하여 로직을 간결화 하고, 백오피스와 서비스에서 사용할 메소드를 분리

[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ