### PR TITLE
[DEV-275] refactor: draft news 저장 및 백오피스 응답 데이터 개선

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -1,6 +1,7 @@
 package com.onedreamus.project.thisismoney.controller;
 
 import com.onedreamus.project.thisismoney.model.dto.*;
+import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsDetailResponse;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsRequest;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsResponse;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.ScheduledNewsResponse;
@@ -143,9 +144,9 @@ public class BackOfficeController {
 
     @GetMapping("/contents/news/drafts/{draftId}")
     @Operation(summary = "임시 저장 콘텐츠 상세 데이터 조회", description = "ID 값을 통해 특정 임시 저장 콘텐츠를 조회합니다.")
-    public ResponseEntity<DraftNewsResponse> getDraftNews(@PathVariable("draftId") Integer draftId) {
-        DraftNewsResponse draftNewsResponse = draftNewsService.getDraftNews(draftId);
-        return ResponseEntity.ok(draftNewsResponse);
+    public ResponseEntity<DraftNewsDetailResponse> getDraftNews(@PathVariable("draftId") Integer draftId) {
+        DraftNewsDetailResponse draftNewsDetailResponse = draftNewsService.getDraftNews(draftId);
+        return ResponseEntity.ok(draftNewsDetailResponse);
     }
 
     @DeleteMapping("/contents/news/drafts{draftId}")

--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -130,7 +130,7 @@ public class BackOfficeController {
             @RequestPart DraftNewsRequest draftNewsRequest,
             @RequestPart List<DictionarySentenceRequest> dictionarySentenceList,
             @RequestPart(required = false) MultipartFile thumbnailImage) {
-        draftNewsService.saveDrafts(draftNewsRequest, dictionarySentenceList, thumbnailImage);
+        draftNewsService.createDraft(draftNewsRequest, dictionarySentenceList, thumbnailImage);
         return ResponseEntity.ok("임시 저장 완료");
     }
 

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionaryDescriptionDto.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/DictionaryDescriptionDto.java
@@ -17,6 +17,11 @@ public class DictionaryDescriptionDto {
     private String definition;
     private Long dictionaryId;
     private String term;
+
+    public static DictionaryDescriptionDto defaultInstance(){
+        return new DictionaryDescriptionDto();
+    }
+
     /**
      * Dictionary 정보를 이용
      */

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/NewsDetailResponse.java
@@ -18,6 +18,7 @@ public class NewsDetailResponse {
     private String newsAgency; // 언론사
     private String fullSentence; // 전체 내용 -> 각 문장들을 함친 내용
     private String link; // 원문 링크
+    private String thumbnailUrl; // 써네일 이미지 URL
     private List<DictionaryDescriptionDto> descriptions; // 각 문장에 대한 설명
 
     public static NewsDetailResponse from(News news, String fullSentence,
@@ -26,6 +27,7 @@ public class NewsDetailResponse {
             .title(news.getTitle())
             .newsAgency(news.getNewsAgency())
             .fullSentence(fullSentence)
+            .thumbnailUrl(news.getThumbnailUrl())
             .descriptions(descriptions)
             .link(news.getLink())
             .build();

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
@@ -22,6 +22,7 @@ public class ScheduledNewsDetailResponse {
     private String newsAgency; // 언론사
     private String fullSentence; // 전체 내용 -> 각 문장들을 함친 내용
     private String link; // 원문 링크
+    private String thumbnailUrl;
     private List<DictionaryDescriptionDto> descriptions; // 각 문장에 대한 설명
     private LocalDate scheduledAt;
 
@@ -31,6 +32,7 @@ public class ScheduledNewsDetailResponse {
         return ScheduledNewsDetailResponse.builder()
                 .title(request.getTitle())
                 .newsAgency(request.getNewsAgency())
+                .thumbnailUrl(scheduledNews.getNewsContent().getThumbnailUrl())
                 .fullSentence(request.getDictionarySentenceList().stream()
                         .map(DictionarySentenceRequest::getSentenceValue)
                         .collect(Collectors.joining()))

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/backOffice/DraftNewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/backOffice/DraftNewsDetailResponse.java
@@ -1,0 +1,34 @@
+package com.onedreamus.project.thisismoney.model.dto.backOffice;
+
+import com.onedreamus.project.thisismoney.model.dto.DictionaryDescriptionDto;
+import com.onedreamus.project.thisismoney.model.entity.DraftNews;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class DraftNewsDetailResponse {
+
+    private String title;
+    private String newsAgency; // 언론사
+    private String fullSentence; // 전체 내용 -> 각 문장들을 함친 내용
+    private String link; // 원문 링크
+    private String thumbnailUrl;
+    private List<DictionaryDescriptionDto> descriptions; // 각 문장에 대한 설명
+    private LocalDate scheduledAt;
+
+    public static DraftNewsDetailResponse from(LocalDate scheduledAt, NewsContent newsContent, List<DictionaryDescriptionDto> dictionaryDescriptionDtos
+            ,String fullSentence) {
+        return DraftNewsDetailResponse.builder()
+                .title(newsContent.getTitle())
+                .newsAgency(newsContent.getNewsAgency())
+                .fullSentence(fullSentence)
+                .descriptions(dictionaryDescriptionDtos)
+                .scheduledAt(scheduledAt)
+                .build();
+    }
+}

--- a/src/main/java/com/onedreamus/project/thisismoney/model/entity/DraftNews.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/entity/DraftNews.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Builder
-public class DraftNews {
+public class DraftNews extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,13 +28,11 @@ public class DraftNews {
     private NewsContent newsContent;
 
     private LocalDate scheduledAt;
-    private LocalDateTime createdAt;
 
     public static DraftNews from(NewsContent newsContent, LocalDate scheduledAt) {
         return DraftNews.builder()
                 .newsContent(newsContent)
                 .scheduledAt(scheduledAt)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/repository/DraftNewsRepository.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/repository/DraftNewsRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DraftNewsRepository extends JpaRepository<DraftNews, Integer> {
-    Page<DraftNews> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<DraftNews> findAllByOrderByUpdatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/DraftNewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/DraftNewsService.java
@@ -4,7 +4,9 @@ import com.onedreamus.project.global.exception.ErrorCode;
 import com.onedreamus.project.global.s3.ImageCategory;
 import com.onedreamus.project.global.s3.S3Uploader;
 import com.onedreamus.project.thisismoney.exception.BackOfficeException;
+import com.onedreamus.project.thisismoney.model.dto.DictionaryDescriptionDto;
 import com.onedreamus.project.thisismoney.model.dto.DictionarySentenceRequest;
+import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsDetailResponse;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsRequest;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsResponse;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.NewsContent;
@@ -19,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,16 +31,18 @@ public class DraftNewsService {
 
     private final DraftNewsRepository draftNewsRepository;
     private final S3Uploader s3Uploader;
+    private final NewsService newsService;
 
     /**
      * <p>콘텐츠 임시 저장</p>
+     *
      * @param draftNewsRequest
      * @param dictionarySentenceList
      * @param thumbnailImage
      */
     @Transactional
     public void createDraft(DraftNewsRequest draftNewsRequest, List<DictionarySentenceRequest> dictionarySentenceList,
-                            MultipartFile thumbnailImage){
+                            MultipartFile thumbnailImage) {
 
         // 기존 임시 저장 콘텐츠의 ID를 가지고 있을 경우 수정 로직 진행
         if (draftNewsRequest.getDraftNewsId() != null) {
@@ -57,7 +63,7 @@ public class DraftNewsService {
      */
     @Transactional
     private void updateDrafts(DraftNewsRequest draftNewsRequest, List<DictionarySentenceRequest> dictionarySentenceList,
-                              MultipartFile thumbnailImage){
+                              MultipartFile thumbnailImage) {
         DraftNews draftNews = draftNewsRepository.findById(draftNewsRequest.getDraftNewsId())
                 .orElseThrow(() -> new BackOfficeException(ErrorCode.CONTENT_NOT_EXIST));
 
@@ -76,8 +82,9 @@ public class DraftNewsService {
 
     /**
      * 이미지 업로드 관리
+     *
      * @param existingThumbnail 기존 이미지
-     * @param newThumbnail 새로운 이미지 파일(MultiparFile)
+     * @param newThumbnail      새로운 이미지 파일(MultiparFile)
      * @return 이미지 URL
      */
     private String updateThumbnail(String existingThumbnail, MultipartFile newThumbnail) {
@@ -96,6 +103,7 @@ public class DraftNewsService {
 
     /**
      * <p>임시 저장 콘텐츠 리스트 조회</p>
+     *
      * @return <code>Page< DraftNewsResponse ></code>
      */
     public Page<DraftNewsResponse> getDraftList(Pageable pageable) {
@@ -104,16 +112,65 @@ public class DraftNewsService {
     }
 
     /**
-     * 주어진 draftId를 사용하여 임시 저장된 뉴스 콘텐츠의 상세 정보를 조회합니다.
+     * <p>주어진 draftId를 사용하여 임시 저장된 뉴스 콘텐츠의 상세 정보를 조회합니다.</p>
      *
      * @param draftId 임시 저장된 뉴스 콘텐츠의 고유 식별자 (Long 타입)
      * @return 임시 저장된 뉴스 콘텐츠의 상세 정보를 담은 DraftNewsResponse 객체
      * @throws BackOfficeException 해당 draftId에 대한 콘텐츠를 찾을 수 없는 경우 발생
      */
-    public DraftNewsResponse getDraftNews(Integer draftId) {
-        return draftNewsRepository.findById(draftId)
-                .map(DraftNewsResponse::from)
+    public DraftNewsDetailResponse getDraftNews(Integer draftId) {
+        // 1. draftID로 임시 저장된 뉴스 콘텐츠 조회
+        DraftNews draftNews = draftNewsRepository.findById(draftId)
                 .orElseThrow(() -> new BackOfficeException(ErrorCode.CONTENT_NOT_EXIST));
+
+        NewsContent newsContent = draftNews.getNewsContent();
+
+        // 2. 뉴스 콘텐츠 용어 설명 리스트 변환 (하이라이팅 적용)
+        List<DictionaryDescriptionDto> dictionaryDescriptionDtos =
+                newsContent.getDictionarySentenceList().stream()
+                        .map(this::convertToDictionaryDescription)
+                        .toList();
+
+        // 3. 전체 문장을 연결하여 fullSentence 생성
+        String fullSentence = dictionaryDescriptionDtos.stream()
+                .map(DictionaryDescriptionDto::getSentence)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining());
+
+        return DraftNewsDetailResponse.from(draftNews.getScheduledAt(), newsContent, dictionaryDescriptionDtos, fullSentence);
+    }
+
+    /**
+     * DictionarySentenceRequest 객체를 DictionaryDescriptionDto로 변환
+     * <p>
+     * - 용어가 존재하면 정의 및 문장(sentence) 하이라이팅 처리
+     * - 용어 정의가 없을 경우 문장만 하이라이팅
+     * - 용어 단어가 없으면 변환 없이 원본 데이터 유지
+     *
+     * @param dictionarySentenceRequest
+     * @return
+     */
+    private DictionaryDescriptionDto convertToDictionaryDescription(DictionarySentenceRequest dictionarySentenceRequest) {
+        // 용어 정보가 없는 경우 기존 데이터 유지
+        if (dictionarySentenceRequest.getDictionaryTerm() == null || dictionarySentenceRequest.getStartIdx() == null ||
+                dictionarySentenceRequest.getEndIdx() == null) {
+            return DictionaryDescriptionDto.from(dictionarySentenceRequest);
+        }
+
+        String highlightedDefinition = null;
+        String highlightedSentence = null;
+
+        // 용어 정의가 존재하면 하이라이팅
+        if (dictionarySentenceRequest.getDictionaryDefinition() != null) {
+            highlightedDefinition = newsService.addHighlightMarkDefinition(dictionarySentenceRequest.getDictionaryDefinition(), dictionarySentenceRequest.getDictionaryTerm());
+        }
+
+        // 문장이 존재하면 하이라이팅
+        if (dictionarySentenceRequest.getSentenceValue() != null) {
+            highlightedSentence = newsService.addHighlightMark(dictionarySentenceRequest.getSentenceValue(), dictionarySentenceRequest.getStartIdx(), dictionarySentenceRequest.getEndIdx());
+        }
+
+        return DictionaryDescriptionDto.fromWithHighlighting(dictionarySentenceRequest, highlightedDefinition, highlightedSentence);
     }
 
     public void deleteDraftNews(Integer draftId) {

--- a/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/NewsService.java
@@ -271,7 +271,7 @@ public class NewsService {
 
     public String addHighlightMarkDefinition(String definition, String term) {
         int startIdx = definition.indexOf(term);
-        // 예외 방지
+        // 예외 방지 - 기존 데이터 하이라이팅 없이 유지
         if (startIdx == -1) {
             return definition;
         }
@@ -282,6 +282,7 @@ public class NewsService {
     }
 
     public String addHighlightMark(String sentence, int startIdx, int endIdx) {
+        // 하이라이팅을 할 수 없는 경우 하이라이팅 없음
         if (startIdx < 0 || endIdx >= sentence.length() || startIdx > endIdx) {
             return sentence;
         }


### PR DESCRIPTION
## Description
> issue : [DEV-275]

- draft news 저장 및 수정 로직을 개선하여 가독성 향상
  - saveDraft() → createDraft() 및 updateDraft()로 분리
  - createdAt 대신 updatedAt을 추가하여 수정 시간만 갱신
  - 썸네일 처리 로직을 updateThumbnail() 메서드로 분리하여 중복 제거

- 백오피스 상세 조회 및 임시 저장 API 응답 개선
  - 상세 조회 응답 값에 thumbnailUrl 필드 추가
  - API 응답 형식을 업로드 예약 콘텐츠 조회와 동일하게 변경하여 프론트 코드 재사용 가능하도록 수정
  - 용어, 문장, 정의 유무에 따라 하이라이팅 처리

[DEV-275]: https://6bit.atlassian.net/browse/DEV-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ