### PR TITLE
[DEV-275] fix : 임시 저장에 빠진 응답 값 추가

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/backOffice/DraftNewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/backOffice/DraftNewsDetailResponse.java
@@ -21,14 +21,17 @@ public class DraftNewsDetailResponse {
     private List<DictionaryDescriptionDto> descriptions; // 각 문장에 대한 설명
     private LocalDate scheduledAt;
 
-    public static DraftNewsDetailResponse from(LocalDate scheduledAt, NewsContent newsContent, List<DictionaryDescriptionDto> dictionaryDescriptionDtos
-            ,String fullSentence) {
+    public static DraftNewsDetailResponse from(LocalDate scheduledAt, NewsContent newsContent,
+        List<DictionaryDescriptionDto> dictionaryDescriptionDtos
+        , String fullSentence) {
         return DraftNewsDetailResponse.builder()
-                .title(newsContent.getTitle())
-                .newsAgency(newsContent.getNewsAgency())
-                .fullSentence(fullSentence)
-                .descriptions(dictionaryDescriptionDtos)
-                .scheduledAt(scheduledAt)
-                .build();
+            .title(newsContent.getTitle())
+            .newsAgency(newsContent.getNewsAgency())
+            .fullSentence(fullSentence)
+            .descriptions(dictionaryDescriptionDtos)
+            .thumbnailUrl(newsContent.getThumbnailUrl())
+            .link(newsContent.getOriginalLink())
+            .scheduledAt(scheduledAt)
+            .build();
     }
 }


### PR DESCRIPTION
## Description
> issue : [DEV-275]
- from() 메소드에서 DraftNewsDetailResponse의 thumbnailUrl, link 필드 추가하도록 수정

[DEV-275]: https://6bit.atlassian.net/browse/DEV-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ