### PR TITLE
업로드 예약 조회 누락된 테이터 추가 및 삭제 메소드 명 수정

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -120,7 +120,7 @@ public class BackOfficeController {
     @DeleteMapping("/contents/news/scheduled/{scheduledNewsId}")
     public ResponseEntity<String> deleteScheduledNews(
         @PathVariable("scheduledNewsId") Integer scheduledNewsId) {
-        scheduledNewsService.deleteScheduledNews(scheduledNewsId);
+        scheduledNewsService.deleteScheduledNewsById(scheduledNewsId);
         return ResponseEntity.ok("업로드 예약 삭제 완료");
     }
 

--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
@@ -30,30 +30,32 @@ public class ScheduledNewsDetailResponse {
         NewsContent request = scheduledNews.getNewsContent();
 
         return ScheduledNewsDetailResponse.builder()
-                .title(request.getTitle())
-                .newsAgency(request.getNewsAgency())
-                .thumbnailUrl(scheduledNews.getNewsContent().getThumbnailUrl())
-                .fullSentence(request.getDictionarySentenceList().stream()
-                        .map(DictionarySentenceRequest::getSentenceValue)
-                        .collect(Collectors.joining()))
-                .descriptions(request.getDictionarySentenceList().stream()
-                        .map(DictionaryDescriptionDto::from)
-                        .toList())
-                .link(request.getOriginalLink())
-                .scheduledAt(scheduledNews.getScheduledAt())
-                .build();
+            .title(request.getTitle())
+            .newsAgency(request.getNewsAgency())
+            .thumbnailUrl(scheduledNews.getNewsContent().getThumbnailUrl())
+            .fullSentence(request.getDictionarySentenceList().stream()
+                .map(DictionarySentenceRequest::getSentenceValue)
+                .collect(Collectors.joining()))
+            .descriptions(request.getDictionarySentenceList().stream()
+                .map(DictionaryDescriptionDto::from)
+                .toList())
+            .link(request.getOriginalLink())
+            .thumbnailUrl(request.getThumbnailUrl())
+            .scheduledAt(scheduledNews.getScheduledAt())
+            .build();
     }
 
-    public static ScheduledNewsDetailResponse from(String title, String newsAgency, String fullSentence,
-                                                   String link, List<DictionaryDescriptionDto> dictionaryDescriptionDtos,
-                                                   LocalDate scheduledAt) {
+    public static ScheduledNewsDetailResponse from(String title, String newsAgency,
+        String fullSentence,
+        String link, List<DictionaryDescriptionDto> dictionaryDescriptionDtos,
+        LocalDate scheduledAt) {
         return ScheduledNewsDetailResponse.builder()
-                .title(title)
-                .newsAgency(newsAgency)
-                .fullSentence(fullSentence)
-                .descriptions(dictionaryDescriptionDtos)
-                .link(link)
-                .scheduledAt(scheduledAt)
-                .build();
+            .title(title)
+            .newsAgency(newsAgency)
+            .fullSentence(fullSentence)
+            .descriptions(dictionaryDescriptionDtos)
+            .link(link)
+            .scheduledAt(scheduledAt)
+            .build();
     }
 }


### PR DESCRIPTION
## Description
> issue : [DEV-254]
- ScheduledNewsDetailResponse.from() 메소드에서 thumbnailUrl 필드에 데이터 추가

> issue : [DEV-278]
- deleteScheduledNews() -> deleteScheduledNewsById() 로 메소드 명 변경
- 메소드를 재사용 하기 위해 ScheduledNews 객체를 받아 사용하던 방법에서 ScheduledNews 의 ID 값을 받아 삭제하는 방법을 수정


[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-278]: https://6bit.atlassian.net/browse/DEV-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ