### PR TITLE
[DEV-254] fix : 업로드 예약 조회 시 누락된 필드 추가

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/model/dto/ScheduledNewsDetailResponse.java
@@ -45,16 +45,17 @@ public class ScheduledNewsDetailResponse {
             .build();
     }
 
-    public static ScheduledNewsDetailResponse from(String title, String newsAgency,
+    public static ScheduledNewsDetailResponse from(NewsContent newsContent,
         String fullSentence,
-        String link, List<DictionaryDescriptionDto> dictionaryDescriptionDtos,
+        List<DictionaryDescriptionDto> dictionaryDescriptionDtos,
         LocalDate scheduledAt) {
         return ScheduledNewsDetailResponse.builder()
-            .title(title)
-            .newsAgency(newsAgency)
+            .title(newsContent.getTitle())
+            .newsAgency(newsContent.getNewsAgency())
             .fullSentence(fullSentence)
             .descriptions(dictionaryDescriptionDtos)
-            .link(link)
+            .thumbnailUrl(newsContent.getThumbnailUrl())
+            .link(newsContent.getOriginalLink())
             .scheduledAt(scheduledAt)
             .build();
     }


### PR DESCRIPTION
## Description
> issue : [DEV-254]

- ScheduledNewsDetailResponse.from() 메소드에서 thumbnailUrl 필드에 데이터 추가

[DEV-254]: https://6bit.atlassian.net/browse/DEV-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ