### PR TITLE
[DEV-279] refactor: 즉시 업로드 및 예약 업로드 시 임시 저장 데이터 삭제 처리

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/controller/BackOfficeController.java
@@ -6,6 +6,7 @@ import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsRequest;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.DraftNewsResponse;
 import com.onedreamus.project.thisismoney.model.dto.backOffice.ScheduledNewsResponse;
 import com.onedreamus.project.thisismoney.service.AgencyService;
+import com.onedreamus.project.thisismoney.service.BackofficeService;
 import com.onedreamus.project.thisismoney.service.DraftNewsService;
 import com.onedreamus.project.thisismoney.service.NewsService;
 import com.onedreamus.project.thisismoney.service.ScheduledNewsService;
@@ -30,26 +31,36 @@ public class BackOfficeController {
     private final ScheduledNewsService scheduledNewsService;
     private final NewsService newsService;
     private final AgencyService agencyService;
-
+    private final DraftNewsService draftNewsService;
+    private final BackofficeService backofficeService;
 
     /*
     ======== [News] ========
      */
 
     @PostMapping("/contents/news")
-    @Operation(summary = "뉴스 콘텐츠 즉시 업로드", description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다.")
+    @Operation(summary = "뉴스 콘텐츠 즉시 업로드",
+        description = "API가 호출되면 즉시 뉴스 콘텐츠 업로드 동작을 수행합니다. " +
+            "임시 저장된 데이터를 완성시켜 업로드 요청을 보내는 경우, " +
+            "임시 저장 뉴스 ID 값을 쿼리 파라미터로 함께 요청을 보내야 합니다.")
     public ResponseEntity<String> uploadNews(
-            @RequestPart @Valid NewsRequest newsRequest,
-            @RequestPart @Valid List<DictionarySentenceRequest> dictionarySentenceList,
-            @RequestPart MultipartFile thumbnailImage) {
+        @RequestPart @Valid NewsRequest newsRequest,
+        @RequestPart @Valid List<DictionarySentenceRequest> dictionarySentenceList,
+        @RequestPart MultipartFile thumbnailImage,
+        @RequestParam(value = "draftNewsId", required = false) Integer draftNewsId) {
+        if (draftNewsId != null) {
+            draftNewsService.deleteDraftNews(draftNewsId);
+        }
+
         newsService.uploadNews(newsRequest, thumbnailImage, dictionarySentenceList);
+        backofficeService.uploadNews(draftNewsId, newsRequest, thumbnailImage, dictionarySentenceList);
         return ResponseEntity.ok("콘텐츠 등록 완료");
     }
 
     @GetMapping("/contents/news")
     @Operation(summary = "업로드 된 뉴스 콘텐츠 리스트 조회", description = "페이지네이션 된 업로드 뉴스 콘텐츠 리스트를 조회합니다.")
     public ResponseEntity<Page<NewsResponse>> getNewsList(
-            @PageableDefault Pageable pageable
+        @PageableDefault Pageable pageable
     ) {
         Page<NewsResponse> newsResponsePage = newsService.getNewsList(pageable);
         return ResponseEntity.ok(newsResponsePage);
@@ -58,8 +69,9 @@ public class BackOfficeController {
     @GetMapping("/contents/news/{newsId}")
     @Operation(summary = "업로드 된 뉴스 콘텐츠 상세 데이터 조회", description = "ID 값으로 업로드 된 뉴스 콘텐츠 조회")
     public ResponseEntity<NewsDetailResponse> getNewsDetail(
-            @PathVariable("newsId") Integer newsId) {
-        NewsDetailResponse newsDetailResponse = newsService.getNewsDetailWithoutViewIncrease(newsId);
+        @PathVariable("newsId") Integer newsId) {
+        NewsDetailResponse newsDetailResponse = newsService.getNewsDetailWithoutViewIncrease(
+            newsId);
         return ResponseEntity.ok(newsDetailResponse);
     }
 
@@ -70,49 +82,55 @@ public class BackOfficeController {
 
 
     @PostMapping("/contents/news/scheduled/{scheduledAt}")
-    @Operation(summary = "뉴스 콘텐츠 업로드 예약", description = "뉴스 콘텐츠 업로드 날짜를 설정하고 예약 합니다.")
+    @Operation(summary = "뉴스 콘텐츠 업로드 예약",
+        description = "뉴스 콘텐츠 업로드 날짜를 설정하고 예약합니다. " +
+            "임시 저장된 데이터를 완성시켜 업로드 요청을 보내는 경우, " +
+            "임시 저장 뉴스 ID 값을 쿼리 파라미터로 함께 요청을 보내야 합니다.")
     public ResponseEntity<String> scheduleContentUpload(
-            @RequestPart @Valid NewsRequest newsRequest,
-            @RequestPart @Valid List<DictionarySentenceRequest> dictionarySentenceList,
-            @RequestPart MultipartFile thumbnailImage,
-            @PathVariable("scheduledAt") LocalDate scheduledAt) {
-        scheduledNewsService.scheduleUploadNews(newsRequest, thumbnailImage, dictionarySentenceList, scheduledAt);
+        @RequestPart @Valid NewsRequest newsRequest,
+        @RequestPart @Valid List<DictionarySentenceRequest> dictionarySentenceList,
+        @RequestPart MultipartFile thumbnailImage,
+        @PathVariable("scheduledAt") LocalDate scheduledAt,
+        @RequestParam(value = "draftNewsId", required = false) Integer draftNewsId) {
+        backofficeService.uploadScheduledNews(draftNewsId, newsRequest, thumbnailImage, dictionarySentenceList, scheduledAt);
         return ResponseEntity.ok("콘텐츠 등록 완료");
     }
 
     @PutMapping("/contents/news/scheduled/{scheduledNewsId}/{scheduledAt}")
     @Operation(summary = "예약 콘텐츠 수정", description = "업로드 예약된 콘텐츠 수정 상세 데이터를 수정합니다.")
     public ResponseEntity<String> updateScheduledContent(
-            @RequestPart @Valid NewsRequest newsRequest,
-            @RequestPart @Valid List<DictionarySentenceRequest> dictionarySentenceList,
-            @RequestPart(required = false) MultipartFile thumbnailImage,
-            @PathVariable("scheduledAt") LocalDate scheduledAt,
-            @PathVariable("scheduledNewsId") Integer scheduledNewsId) {
-        scheduledNewsService.updateScheduledNews(newsRequest, thumbnailImage, dictionarySentenceList, scheduledAt, scheduledNewsId);
+        @RequestPart @Valid NewsRequest newsRequest,
+        @RequestPart @Valid List<DictionarySentenceRequest> dictionarySentenceList,
+        @RequestPart(required = false) MultipartFile thumbnailImage,
+        @PathVariable("scheduledAt") LocalDate scheduledAt,
+        @PathVariable("scheduledNewsId") Integer scheduledNewsId) {
+        scheduledNewsService.updateScheduledNews(newsRequest, thumbnailImage,
+            dictionarySentenceList, scheduledAt, scheduledNewsId);
         return ResponseEntity.ok("업데이트 완료");
     }
 
     @GetMapping("/contents/news/scheduled")
     @Operation(summary = "예약 뉴스 업로드 리스트 조회", description = "페이지네이션 된 예약한 뉴스 업로드 리스트를 조회합니다.")
     public ResponseEntity<Page<ScheduledNewsResponse>> getScheduledNewsList(
-            @PageableDefault Pageable pageable) {
+        @PageableDefault Pageable pageable) {
         Page<ScheduledNewsResponse> scheduledNewsPage = scheduledNewsService.getScheduledNewsList(
-                pageable);
+            pageable);
         return ResponseEntity.ok(scheduledNewsPage);
     }
 
     @GetMapping("/contents/news/scheduled/{scheduledNewsId}")
     @Operation(summary = "업로드 예약 된 뉴스 콘텐츠 상세 데이터 조회", description = "ID 값으로 업로드 예약 된 뉴스 콘텐츠 조회")
     public ResponseEntity<ScheduledNewsDetailResponse> getScheduledNewsDetail(
-            @PathVariable("scheduledNewsId") Integer newsId) {
-        ScheduledNewsDetailResponse scheduledNewsDetail = scheduledNewsService.getScheduledNewsDetail(newsId);
+        @PathVariable("scheduledNewsId") Integer newsId) {
+        ScheduledNewsDetailResponse scheduledNewsDetail = scheduledNewsService.getScheduledNewsDetail(
+            newsId);
         return ResponseEntity.ok(scheduledNewsDetail);
     }
 
     @GetMapping("/agency/{keyword}")
     @Operation(summary = "뉴스사 검색", description = "keyword를 포함하는 모든 뉴스사를 조회합니다.")
     public ResponseEntity<List<AgencySearch>> searchAgency(
-            @PathVariable("keyword") String keyword) {
+        @PathVariable("keyword") String keyword) {
         List<AgencySearch> agencySearches = agencyService.searchAgency(keyword);
         return ResponseEntity.ok(agencySearches);
     }
@@ -130,28 +148,28 @@ public class BackOfficeController {
      */
 
 
-    private final DraftNewsService draftNewsService;
-
     @PostMapping("/contents/news/drafts")
     @Operation(summary = "콘텐츠 임시 저장 및 수정", description = "작성 중이던 콘텐츠를 임시 저장 합니다.")
     public ResponseEntity<String> saveDrafts(
-            @RequestPart DraftNewsRequest draftNewsRequest,
-            @RequestPart List<DictionarySentenceRequest> dictionarySentenceList,
-            @RequestPart(required = false) MultipartFile thumbnailImage) {
+        @RequestPart DraftNewsRequest draftNewsRequest,
+        @RequestPart List<DictionarySentenceRequest> dictionarySentenceList,
+        @RequestPart(required = false) MultipartFile thumbnailImage) {
         draftNewsService.createDraft(draftNewsRequest, dictionarySentenceList, thumbnailImage);
         return ResponseEntity.ok("임시 저장 완료");
     }
 
     @GetMapping("/contents/news/drafts")
     @Operation(summary = "임시 저장 콘텐츠 리스트 조회", description = "페이지네이션 된 임시 저장 항목 리스트를 조회합니다.")
-    public ResponseEntity<Page<DraftNewsResponse>> getDraftList(@PageableDefault Pageable pageable) {
+    public ResponseEntity<Page<DraftNewsResponse>> getDraftList(
+        @PageableDefault Pageable pageable) {
         Page<DraftNewsResponse> draftNewsPage = draftNewsService.getDraftList(pageable);
         return ResponseEntity.ok(draftNewsPage);
     }
 
     @GetMapping("/contents/news/drafts/{draftId}")
     @Operation(summary = "임시 저장 콘텐츠 상세 데이터 조회", description = "ID 값을 통해 특정 임시 저장 콘텐츠를 조회합니다.")
-    public ResponseEntity<DraftNewsDetailResponse> getDraftNews(@PathVariable("draftId") Integer draftId) {
+    public ResponseEntity<DraftNewsDetailResponse> getDraftNews(
+        @PathVariable("draftId") Integer draftId) {
         DraftNewsDetailResponse draftNewsDetailResponse = draftNewsService.getDraftNews(draftId);
         return ResponseEntity.ok(draftNewsDetailResponse);
     }

--- a/src/main/java/com/onedreamus/project/thisismoney/service/BackofficeService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/BackofficeService.java
@@ -1,0 +1,72 @@
+package com.onedreamus.project.thisismoney.service;
+
+import com.onedreamus.project.thisismoney.model.dto.DictionarySentenceRequest;
+import com.onedreamus.project.thisismoney.model.dto.NewsRequest;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BackofficeService {
+
+    private final DraftNewsService draftNewsService;
+    private final ScheduledNewsService scheduledNewsService;
+    private final NewsService newsService;
+
+    /**
+     * 뉴스 콘텐츠 예약 업로드 (임시 저장 데이터 삭제 포함)
+     *
+     * @param draftNewsId 삭제할 임시 뉴스 ID (선택적)
+     * @param newsRequest 뉴스 요청 데이터
+     * @param thumbnailImage 썸네일 이미지
+     * @param dictionarySentenceList 용어 문장 리스트
+     * @param scheduledAt 예약할 날짜
+     */
+    @Transactional
+    public void uploadScheduledNews(Integer draftNewsId, NewsRequest newsRequest,
+        MultipartFile thumbnailImage, List<DictionarySentenceRequest> dictionarySentenceList,
+        LocalDate scheduledAt) {
+        // 임시 저장 데이터에서 작성된 경우 임시저장 데이터 삭제
+        deleteDraftIfExists(draftNewsId);
+
+        // 뉴스 콘텐츠 업로드 예약
+        scheduledNewsService.scheduleUploadNews(newsRequest, thumbnailImage, dictionarySentenceList,
+            scheduledAt);
+    }
+
+    /**
+     * 뉴스 콘텐츠 즉시 업로드 (임시 저장 데이터 삭제 포함)
+     *
+     * @param draftNewsId 삭제할 임시 뉴스 ID (선택적)
+     * @param newsRequest 뉴스 요청 데이터
+     * @param thumbnailImage 썸네일 이미지
+     * @param dictionarySentenceList 용어 문장 리스트
+     */
+    @Transactional
+    public void uploadNews(Integer draftNewsId, NewsRequest newsRequest,
+        MultipartFile thumbnailImage,
+        List<DictionarySentenceRequest> dictionarySentenceList) {
+        // 임시 저장 데이터에서 작성된 경우 임시저장 데이터 삭제
+        deleteDraftIfExists(draftNewsId);
+
+        // 뉴스 콘텐츠 업로드
+        newsService.uploadNews(newsRequest, thumbnailImage, dictionarySentenceList);
+    }
+
+    /**
+     * 임시 저장 뉴스 데이터가 존재하는 경우 삭제
+     *
+     * @param draftNewsId 삭제할 임시 뉴스 ID (null이면 동작하지 않음)
+     */
+    private void deleteDraftIfExists(Integer draftNewsId){
+        if (draftNewsId != null) {
+            draftNewsService.deleteDraftNews(draftNewsId);
+        }
+    }
+}


### PR DESCRIPTION
## Description
> issue : [DEV-279]
- draftNewsId가 있을 경우, 임시 저장된 데이터를 완성 후 업로드하는 것으로 판단하여 삭제하도록 변경
- BackOfficeService에서 @Transactional을 적용하여 데이터 정합성을 보장
- 중복된 draft 삭제 로직을 정리하고 서비스 계층에서 일관되게 처리

[DEV-279]: https://6bit.atlassian.net/browse/DEV-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ