### PR TITLE
[DEV-286] refactor: User quizAttempt 변경 로직 수정

### DIFF
--- a/src/main/java/com/onedreamus/project/thisismoney/service/QuizService.java
+++ b/src/main/java/com/onedreamus/project/thisismoney/service/QuizService.java
@@ -264,6 +264,7 @@ public class QuizService {
         // 첫 번째 퀴즈 시도인 경우
         if (!user.isQuizAttempt()) {
             user.setQuizAttempt(true);
+            userService.saveUser(user);
         }
 
         // 퀴즈 미션 상태 수정


### PR DESCRIPTION
## Description
> issue : [DEV-286]

- 수정된 User 엔티티를 save() 메소드로 직접 저장하도록 수정
- 영속성이 이미 분리된 상태이기 때문에 @Transactional 어노테이션이 있어도 변경된 값 flush 되지 않음.

[DEV-286]: https://6bit.atlassian.net/browse/DEV-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ